### PR TITLE
fix(provider/typed-list): handle nil element types

### DIFF
--- a/internal/provider/attr_value_test.go
+++ b/internal/provider/attr_value_test.go
@@ -1,0 +1,18 @@
+package provider_test
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+)
+
+type attrValueTypeNil struct {
+	attr.Value
+}
+
+var _ attr.Value = attrValueTypeNil{}
+
+//nolint:ireturn
+func (t attrValueTypeNil) Type(_ context.Context) attr.Type {
+	return nil
+}

--- a/internal/provider/typed_list_test.go
+++ b/internal/provider/typed_list_test.go
@@ -432,11 +432,10 @@ func TestTypedListLen(t *testing.T) {
 func TestTypedListTypeAndCustomType(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-
 	t.Run("Type returns correct type", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := t.Context()
 		value := NewTypedList([]types.String{types.StringValue("test")})
 		attrType := value.Type(ctx)
 
@@ -447,6 +446,7 @@ func TestTypedListTypeAndCustomType(t *testing.T) {
 	t.Run("CustomType returns correct type", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := t.Context()
 		value := NewTypedList([]types.String{types.StringValue("test")})
 		customType := value.CustomType(ctx)
 
@@ -457,6 +457,7 @@ func TestTypedListTypeAndCustomType(t *testing.T) {
 	t.Run("Type and CustomType are equal", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := t.Context()
 		value := NewTypedList([]types.String{})
 		assert.True(t, value.Type(ctx).Equal(value.CustomType(ctx)))
 	})

--- a/internal/provider/typed_list_type.go
+++ b/internal/provider/typed_list_type.go
@@ -96,6 +96,10 @@ func (t TypedListType[T]) Equal(o attr.Type) bool {
 		return true
 	}
 
+	if elementType == nil || otherElementType == nil {
+		return false
+	}
+
 	return elementType.Equal(otherElementType)
 }
 

--- a/internal/provider/typed_list_type_test.go
+++ b/internal/provider/typed_list_type_test.go
@@ -256,3 +256,28 @@ func TestTypedListTypeEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestTypedListTypeEqualOneNilElementType(t *testing.T) {
+	t.Parallel()
+
+	typedListNil := NewTypedListNull[attrValueTypeNil]()
+	typedListString := NewTypedListNull[types.String]()
+
+	t.Run("left", func(t *testing.T) {
+		t.Parallel()
+
+		typedListNilType := typedListNil.Type(t.Context())
+		typedListStringType := typedListString.Type(t.Context())
+
+		assert.False(t, typedListNilType.Equal(typedListStringType))
+	})
+
+	t.Run("right", func(t *testing.T) {
+		t.Parallel()
+
+		typedListNilType := typedListNil.Type(t.Context())
+		typedListStringType := typedListString.Type(t.Context())
+
+		assert.False(t, typedListStringType.Equal(typedListNilType))
+	})
+}


### PR DESCRIPTION
Add nil check before calling Equal on element types to prevent panic when comparing TypedListTypes where one has a nil element type.