### PR TITLE
fix(provider/content_block): continue with next resource after failure to retrieve a list item

### DIFF
--- a/internal/provider/braze_content_block_list_resource.go
+++ b/internal/provider/braze_content_block_list_resource.go
@@ -136,6 +136,8 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 					if !yield(result) {
 						return
 					}
+
+					continue
 				}
 
 				data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)


### PR DESCRIPTION
When GetContentBlockInfo fails, skip processing that block instead of attempting to create a model from a nil response. This prevents a potential nil pointer dereference panic.