### PR TITLE
chore(golangci): adjust noisy lint checks

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -24,5 +24,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.6.2
+          version: v2.12.2
           skip-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - depguard
     - exhaustruct
     - funlen
+    - goconst
     - lll
     - wsl
   settings:
@@ -31,6 +32,10 @@ linters:
       - builtin$
       - examples$
     rules:
+      - linters:
+          - gosec
+        path: "internal/provider/http_client_user_agent.go"
+        text: "G704: SSRF via taint analysis"
       - linters:
           - revive
         path: "util/*"


### PR DESCRIPTION
Adjust golangci-lint configuration so current main has a useful passing baseline: disable noisy goconst suggestions and suppress the gosec false positive on the Terraform provider HTTP client wrapper.
