### PR TITLE
Refactor provider content block adapter

### DIFF
--- a/internal/provider/braze_content_block_adapter.go
+++ b/internal/provider/braze_content_block_adapter.go
@@ -1,0 +1,188 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type contentBlockClient interface {
+	Create(ctx context.Context, plan brazeContentBlockModel) (brazeContentBlockModel, error)
+	Read(ctx context.Context, id string) (brazeContentBlockModel, error)
+	Update(ctx context.Context, plan brazeContentBlockModel) (brazeContentBlockModel, error)
+	List(ctx context.Context, query contentBlockListQuery) ([]contentBlockListEntry, error)
+}
+
+type contentBlockListQuery struct {
+	Limit           int
+	ModifiedAfter   *time.Time
+	ModifiedBefore  *time.Time
+	IncludeResource bool
+}
+
+type contentBlockListEntry struct {
+	ID          string
+	DisplayName string
+	Resource    *brazeContentBlockModel
+	ResourceErr error
+}
+
+type contentBlockNotFoundError struct {
+	err error
+}
+
+func (e contentBlockNotFoundError) Error() string {
+	return e.err.Error()
+}
+
+func (e contentBlockNotFoundError) Unwrap() error {
+	return e.err
+}
+
+func isContentBlockNotFound(err error) bool {
+	var notFound contentBlockNotFoundError
+
+	return errors.As(err, &notFound)
+}
+
+type generatedContentBlockClient struct {
+	client *brazeclient.Client
+}
+
+var errContentBlockEmptyResponse = errors.New("empty Braze content block response")
+
+func newGeneratedContentBlockClient(client *brazeclient.Client) generatedContentBlockClient {
+	return generatedContentBlockClient{client: client}
+}
+
+func (c generatedContentBlockClient) Create(ctx context.Context, plan brazeContentBlockModel) (brazeContentBlockModel, error) {
+	createRequest := plan.ToCreateContentBlockRequest()
+
+	createResponse, createErr := c.client.CreateContentBlock(ctx, &createRequest)
+
+	tflog.Info(ctx, "braze_content_block.create", map[string]any{
+		"request":  createRequest,
+		"response": createResponse,
+		"err":      createErr,
+	})
+
+	if createErr != nil {
+		return brazeContentBlockModel{}, createErr
+	}
+
+	if createResponse == nil {
+		return brazeContentBlockModel{}, errContentBlockEmptyResponse
+	}
+
+	return c.Read(ctx, createResponse.GetContentBlockID())
+}
+
+func (c generatedContentBlockClient) Read(ctx context.Context, id string) (brazeContentBlockModel, error) {
+	getParams := brazeclient.GetContentBlockInfoParams{
+		ContentBlockID: id,
+	}
+
+	getResponse, getErr := c.client.GetContentBlockInfo(ctx, getParams)
+
+	tflog.Info(ctx, "braze_content_block.read", map[string]any{
+		"params":   getParams,
+		"response": getResponse,
+		"err":      getErr,
+	})
+
+	if getErr != nil {
+		return brazeContentBlockModel{}, classifyContentBlockReadError(getErr)
+	}
+
+	if getResponse == nil {
+		return brazeContentBlockModel{}, errContentBlockEmptyResponse
+	}
+
+	return NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse), nil
+}
+
+func (c generatedContentBlockClient) Update(ctx context.Context, plan brazeContentBlockModel) (brazeContentBlockModel, error) {
+	updateRequest := plan.ToUpdateContentBlockRequest()
+
+	updateResponse, updateErr := c.client.UpdateContentBlock(ctx, &updateRequest)
+
+	tflog.Info(ctx, "braze_content_block.update", map[string]any{
+		"request":  updateRequest,
+		"response": updateResponse,
+		"err":      updateErr,
+	})
+
+	if updateErr != nil {
+		return brazeContentBlockModel{}, updateErr
+	}
+
+	if updateResponse == nil {
+		return brazeContentBlockModel{}, errContentBlockEmptyResponse
+	}
+
+	return c.Read(ctx, updateResponse.GetContentBlockID())
+}
+
+func (c generatedContentBlockClient) List(ctx context.Context, query contentBlockListQuery) ([]contentBlockListEntry, error) {
+	params := brazeclient.ListContentBlocksParams{
+		Limit: brazeclient.NewOptInt(query.Limit),
+	}
+
+	if query.ModifiedAfter != nil {
+		params.ModifiedAfter = brazeclient.NewOptDateTime(*query.ModifiedAfter)
+	}
+
+	if query.ModifiedBefore != nil {
+		params.ModifiedBefore = brazeclient.NewOptDateTime(*query.ModifiedBefore)
+	}
+
+	listResponse, listErr := c.client.ListContentBlocks(ctx, params)
+
+	tflog.Info(ctx, "braze_content_block.list", map[string]any{
+		"params":   params,
+		"response": listResponse,
+		"err":      listErr,
+	})
+
+	if listErr != nil {
+		return nil, listErr
+	}
+
+	if listResponse == nil {
+		return nil, errContentBlockEmptyResponse
+	}
+
+	entries := make([]contentBlockListEntry, 0, len(listResponse.GetContentBlocks()))
+	for _, block := range listResponse.GetContentBlocks() {
+		entry := contentBlockListEntry{
+			ID:          block.GetContentBlockID(),
+			DisplayName: block.GetName(),
+		}
+
+		if query.IncludeResource {
+			resource, err := c.Read(ctx, entry.ID)
+			if err != nil {
+				entry.ResourceErr = err
+			} else {
+				entry.Resource = &resource
+			}
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func classifyContentBlockReadError(err error) error {
+	var ersc *brazeclient.ErrorResponseStatusCode
+	if errors.As(err, &ersc) && ersc.StatusCode == http.StatusNotFound {
+		return contentBlockNotFoundError{err: err}
+	}
+
+	return err
+}

--- a/internal/provider/braze_content_block_list_resource.go
+++ b/internal/provider/braze_content_block_list_resource.go
@@ -3,14 +3,12 @@ package provider
 import (
 	"context"
 
-	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 //nolint:ireturn
@@ -67,8 +65,9 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 		return
 	}
 
-	params := brazeclient.ListContentBlocksParams{
-		Limit: brazeclient.NewOptInt(int(req.Limit)),
+	query := contentBlockListQuery{
+		Limit:           int(req.Limit),
+		IncludeResource: req.IncludeResource,
 	}
 	paramsDiags := diag.Diagnostics{}
 
@@ -76,14 +75,14 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 		modifiedAfter, modifiedAfterDiags := config.ModifiedAfter.ValueRFC3339Time()
 		paramsDiags.Append(modifiedAfterDiags...)
 
-		params.ModifiedAfter = brazeclient.NewOptDateTime(modifiedAfter)
+		query.ModifiedAfter = &modifiedAfter
 	}
 
 	if !config.ModifiedBefore.IsNull() {
 		modifiedBefore, modifiedBeforeDiags := config.ModifiedBefore.ValueRFC3339Time()
 		paramsDiags.Append(modifiedBeforeDiags...)
 
-		params.ModifiedBefore = brazeclient.NewOptDateTime(modifiedBefore)
+		query.ModifiedBefore = &modifiedBefore
 	}
 
 	if paramsDiags.HasError() {
@@ -93,45 +92,26 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 	}
 
 	resp.Results = func(yield func(list.ListResult) bool) {
-		listResponse, listErr := r.providerData.client.ListContentBlocks(ctx, params)
-
-		tflog.Info(ctx, "braze_content_block.list", map[string]any{
-			"params":   params,
-			"response": listResponse,
-			"err":      listErr,
-		})
-
+		entries, listErr := r.providerData.contentBlocks.List(ctx, query)
 		if listErr != nil {
 			result := req.NewListResult(ctx)
-			result.Diagnostics.AddError("Failed to list content blocks", listErr.Error())
+			result.Diagnostics.AddError("Failed to list content blocks", detailFromError(listErr))
 
 			yield(result)
 
 			return
 		}
 
-		for _, block := range listResponse.GetContentBlocks() {
+		for _, entry := range entries {
 			result := req.NewListResult(ctx)
 
-			result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("id"), block.GetContentBlockID())...)
+			result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("id"), entry.ID)...)
 
-			result.DisplayName = block.GetName()
+			result.DisplayName = entry.DisplayName
 
 			if req.IncludeResource {
-				params := brazeclient.GetContentBlockInfoParams{
-					ContentBlockID: block.GetContentBlockID(),
-				}
-
-				getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, params)
-
-				tflog.Info(ctx, "braze_content_block.list.get", map[string]any{
-					"params":   params,
-					"response": getResponse,
-					"err":      getErr,
-				})
-
-				if getResponse == nil || getErr != nil {
-					result.Diagnostics.AddError("Failed to get content block", detailFromError(getErr))
+				if entry.ResourceErr != nil {
+					result.Diagnostics.AddError("Failed to get content block", detailFromError(entry.ResourceErr))
 
 					if !yield(result) {
 						return
@@ -140,9 +120,7 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 					continue
 				}
 
-				data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
-
-				result.Diagnostics.Append(result.Resource.Set(ctx, data)...)
+				result.Diagnostics.Append(result.Resource.Set(ctx, *entry.Resource)...)
 			}
 
 			if !yield(result) {

--- a/internal/provider/braze_content_block_resource.go
+++ b/internal/provider/braze_content_block_resource.go
@@ -2,13 +2,9 @@ package provider
 
 import (
 	"context"
-	"errors"
-	"net/http"
 
-	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -55,55 +51,18 @@ func (r *brazeContentBlockResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	createRequest := plan.ToCreateContentBlockRequest()
-
-	createResponse, createErr := r.providerData.client.CreateContentBlock(ctx, &createRequest)
-
-	tflog.Info(ctx, "braze_content_block.create", map[string]any{
-		"request":  createRequest,
-		"response": createResponse,
-		"err":      createErr,
-	})
-
-	if createResponse == nil || createErr != nil {
-		resp.Diagnostics.AddError("Failed to create Content Block", detailFromError(createErr))
-
-		return
-	}
-
-	contentBlockID := createResponse.GetContentBlockID()
-
-	resp.Diagnostics.Append(setIdentity(ctx, resp.Identity, &resp.State, contentBlockID)...)
-
-	getParams := brazeclient.GetContentBlockInfoParams{
-		ContentBlockID: contentBlockID,
-	}
-
-	getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_content_block.create.get", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddError("Content Block not found after creation", ersc.Error())
-
-			return
+	data, err := r.providerData.contentBlocks.Create(ctx, plan)
+	if err != nil {
+		if isContentBlockNotFound(err) {
+			resp.Diagnostics.AddError("Content Block not found after creation", detailFromError(err))
+		} else {
+			resp.Diagnostics.AddError("Failed to create Content Block", detailFromError(err))
 		}
 
-		resp.Diagnostics.AddError("Failed to retrieve Content Block after creation", detailFromError(getErr))
-
 		return
 	}
 
-	contentBlockID = getResponse.GetContentBlockID()
-	data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, contentBlockID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeContentBlockResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -115,36 +74,21 @@ func (r *brazeContentBlockResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	getParams := brazeclient.GetContentBlockInfoParams{
-		ContentBlockID: state.ID.ValueString(),
-	}
-
-	getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_content_block.read", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddWarning("Content Block not found", ersc.Error())
+	data, err := r.providerData.contentBlocks.Read(ctx, state.ID.ValueString())
+	if err != nil {
+		if isContentBlockNotFound(err) {
+			resp.Diagnostics.AddWarning("Content Block not found", detailFromError(err))
 			resp.State.RemoveResource(ctx)
 
 			return
 		}
 
-		resp.Diagnostics.AddError("Failed to read Content Block", detailFromError(getErr))
+		resp.Diagnostics.AddError("Failed to read Content Block", detailFromError(err))
 
 		return
 	}
 
-	contentBlockID := getResponse.GetContentBlockID()
-	data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, contentBlockID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeContentBlockResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -156,55 +100,18 @@ func (r *brazeContentBlockResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	updateRequest := plan.ToUpdateContentBlockRequest()
-
-	updateResponse, updateErr := r.providerData.client.UpdateContentBlock(ctx, &updateRequest)
-
-	tflog.Info(ctx, "braze_content_block.update", map[string]any{
-		"request":  updateRequest,
-		"response": updateResponse,
-		"err":      updateErr,
-	})
-
-	if updateResponse == nil || updateErr != nil {
-		resp.Diagnostics.AddError("Failed to update Content Block", detailFromError(updateErr))
-
-		return
-	}
-
-	contentBlockID := updateResponse.GetContentBlockID()
-
-	resp.Diagnostics.Append(setIdentity(ctx, resp.Identity, &resp.State, contentBlockID)...)
-
-	getParams := brazeclient.GetContentBlockInfoParams{
-		ContentBlockID: contentBlockID,
-	}
-
-	getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_content_block.update.get", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddError("Content Block not found after update", ersc.Error())
-
-			return
+	data, err := r.providerData.contentBlocks.Update(ctx, plan)
+	if err != nil {
+		if isContentBlockNotFound(err) {
+			resp.Diagnostics.AddError("Content Block not found after update", detailFromError(err))
+		} else {
+			resp.Diagnostics.AddError("Failed to update Content Block", detailFromError(err))
 		}
 
-		resp.Diagnostics.AddError("Failed to retrieve Content Block after update", detailFromError(getErr))
-
 		return
 	}
 
-	contentBlockID = getResponse.GetContentBlockID()
-	data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, contentBlockID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeContentBlockResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/braze_provider.go
+++ b/internal/provider/braze_provider.go
@@ -132,7 +132,7 @@ func (p *brazeProvider) Configure(ctx context.Context, req provider.ConfigureReq
 	}
 
 	providerData := brazeProviderData{
-		client: brazeClient,
+		contentBlocks: newGeneratedContentBlockClient(brazeClient),
 	}
 
 	resp.ActionData = providerData

--- a/internal/provider/braze_provider_data.go
+++ b/internal/provider/braze_provider_data.go
@@ -1,9 +1,5 @@
 package provider
 
-import (
-	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
-)
-
 type brazeProviderData struct {
-	client *brazeclient.Client
+	contentBlocks contentBlockClient
 }


### PR DESCRIPTION
## Summary

- add a provider-owned Content Block adapter around the generated Braze client
- move generated request/response/error handling out of Terraform resource methods
- route resource and list-resource operations through the new adapter seam

## Why

The handwritten Terraform lifecycle code was coupled directly to generated OAS client types. This draft sketches a narrower provider-owned seam so generated-client translation, not-found classification, read-after-write hydration, and list hydration live in one place.

## Trade-offs

This keeps the first seam intentionally concrete to Content Blocks. It avoids a premature generic Braze repository abstraction, but the adapter still uses `brazeContentBlockModel`, so Terraform framework types are not fully isolated yet.

## Validation

- `go test ./...`
