### PR TITLE
chore: modernize tooling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,11 @@ linters:
     - exhaustruct
     - funlen
     - goconst
+    - gomodguard
     - lll
     - wsl
+  enable:
+    - gomodguard_v2
   settings:
     cyclop:
       max-complexity: 20

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,10 +38,6 @@ linters:
         text: "G704: SSRF via taint analysis"
       - linters:
           - revive
-        path: "util/*"
-        text: "var-naming: avoid meaningless package names"
-      - linters:
-          - revive
         path: ".*_test.go"
         text: "dot-imports: should not use dot imports"
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A Terraform provider for managing Braze configuration.
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 1.12
-- [Go](https://golang.org/doc/install) >= 1.25
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.12
+- [Go](https://go.dev/doc/install) >= 1.25
 
 ## Building the Provider
 

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
-	golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3 // indirect
+	golang.org/x/exp v0.0.0-20260528193900-50dc527dd6c7 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
-golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3 h1:VHEvKbpgPXcPXn40t9cDTGK3JZwMikIEyF/CTrFfu7k=
-golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
+golang.org/x/exp v0.0.0-20260528193900-50dc527dd6c7 h1:cHpkPjp4TILjdZxz/O4ykwCpeS+dDqNuDGse4zgQDCk=
+golang.org/x/exp v0.0.0-20260528193900-50dc527dd6c7/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=


### PR DESCRIPTION
## Summary
- bump the available indirect Go module update
- remove stale golangci-lint config and switch from gomodguard to gomodguard_v2
- update README install links to current canonical docs

## Verification
- go test ./...
- go build -v .
- go generate ./...
- git diff --exit-code
- golangci-lint run