### PR TITLE
Handle Braze rate limit backoff

### DIFF
--- a/internal/provider/braze_provider.go
+++ b/internal/provider/braze_provider.go
@@ -116,7 +116,7 @@ func (p *brazeProvider) Configure(ctx context.Context, req provider.ConfigureReq
 	retryableClient := retryablehttp.NewClient()
 	retryableClient.RetryWaitMin = time.Duration(1) * time.Second
 	retryableClient.RetryWaitMax = time.Duration(3) * time.Second //nolint:mnd
-	retryableClient.Backoff = retryablehttp.LinearJitterBackoff
+	retryableClient.Backoff = brazeRateLimitBackoff
 
 	if p.httpClient != nil {
 		retryableClient.HTTPClient = p.httpClient

--- a/internal/provider/http_client_rate_limit.go
+++ b/internal/provider/http_client_rate_limit.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+const rateLimitResetHeader = "X-Ratelimit-Reset"
+
+func brazeRateLimitBackoff(minDelay, maxDelay time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		if delay, ok := rateLimitDelay(resp.Header, time.Now); ok {
+			return delay
+		}
+	}
+
+	return retryablehttp.LinearJitterBackoff(minDelay, maxDelay, attemptNum, resp)
+}
+
+func rateLimitDelay(header http.Header, now func() time.Time) (time.Duration, bool) {
+	if delay, ok := retryAfterDelay(header.Get("Retry-After"), now); ok {
+		return delay, true
+	}
+
+	resetAt, err := strconv.ParseInt(header.Get(rateLimitResetHeader), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	delay := time.Unix(resetAt, 0).Sub(now())
+	if delay < 0 {
+		return 0, true
+	}
+
+	return delay, true
+}
+
+func retryAfterDelay(value string, now func() time.Time) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	retryAt, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+
+	delay := retryAt.Sub(now())
+	if delay < 0 {
+		return 0, true
+	}
+
+	return delay, true
+}

--- a/internal/provider/http_client_rate_limit_test.go
+++ b/internal/provider/http_client_rate_limit_test.go
@@ -1,0 +1,98 @@
+//nolint:testpackage
+package provider
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestRateLimitDelayUsesRetryAfterSeconds(t *testing.T) {
+	t.Parallel()
+
+	header := http.Header{}
+	header.Set("Retry-After", "12")
+	header.Set(rateLimitResetHeader, "1234567890")
+
+	delay, ok := rateLimitDelay(header, fixedTime)
+	if !ok {
+		t.Fatal("expected rate limit delay")
+	}
+
+	if delay != 12*time.Second {
+		t.Fatalf("expected 12s delay, got %s", delay)
+	}
+}
+
+func TestRateLimitDelayUsesRetryAfterHTTPDate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 29, 10, 0, 0, 0, time.UTC)
+	header := http.Header{}
+	header.Set("Retry-After", now.Add(2*time.Minute).Format(http.TimeFormat))
+
+	delay, ok := rateLimitDelay(header, func() time.Time { return now })
+	if !ok {
+		t.Fatal("expected rate limit delay")
+	}
+
+	if delay != 2*time.Minute {
+		t.Fatalf("expected 2m delay, got %s", delay)
+	}
+}
+
+func TestRateLimitDelayUsesRateLimitReset(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 29, 10, 0, 0, 0, time.UTC)
+	header := http.Header{}
+	header.Set(rateLimitResetHeader, strconvFormatInt(now.Add(45*time.Second).Unix()))
+
+	delay, ok := rateLimitDelay(header, func() time.Time { return now })
+	if !ok {
+		t.Fatal("expected rate limit delay")
+	}
+
+	if delay != 45*time.Second {
+		t.Fatalf("expected 45s delay, got %s", delay)
+	}
+}
+
+func TestRateLimitDelayReturnsZeroForPastReset(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 29, 10, 0, 0, 0, time.UTC)
+	header := http.Header{}
+	header.Set(rateLimitResetHeader, strconvFormatInt(now.Add(-time.Second).Unix()))
+
+	delay, ok := rateLimitDelay(header, func() time.Time { return now })
+	if !ok {
+		t.Fatal("expected rate limit delay")
+	}
+
+	if delay != 0 {
+		t.Fatalf("expected no delay for past reset, got %s", delay)
+	}
+}
+
+func TestRateLimitDelayRejectsInvalidHeaders(t *testing.T) {
+	t.Parallel()
+
+	header := http.Header{}
+	header.Set("Retry-After", "invalid")
+	header.Set(rateLimitResetHeader, "invalid")
+
+	delay, ok := rateLimitDelay(header, fixedTime)
+	if ok {
+		t.Fatalf("expected invalid headers to be ignored, got %s", delay)
+	}
+}
+
+func fixedTime() time.Time {
+	return time.Date(2026, time.May, 29, 10, 0, 0, 0, time.UTC)
+}
+
+func strconvFormatInt(value int64) string {
+	return strconv.FormatInt(value, 10)
+}


### PR DESCRIPTION
## Summary
- retry Braze 429 responses using Retry-After when present
- fall back to Braze X-RateLimit-Reset epoch seconds before using jitter backoff
- add deterministic unit coverage for rate-limit delay parsing

## Testing
- go test ./...
- golangci-lint run