### PR TITLE
Paginate content block list results

### DIFF
--- a/internal/braze-client-go/testing/handler_content_blocks.go
+++ b/internal/braze-client-go/testing/handler_content_blocks.go
@@ -5,17 +5,26 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"sort"
 
 	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
 	"github.com/google/uuid"
 )
 
-func (h *Handler) ListContentBlocks(_ context.Context, _ brazeclient.ListContentBlocksParams) (*brazeclient.ListContentBlocksResponse, error) {
+func (h *Handler) ListContentBlocks(_ context.Context, params brazeclient.ListContentBlocksParams) (*brazeclient.ListContentBlocksResponse, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	ids := make([]string, 0, len(h.contentBlocks))
+	for id := range h.contentBlocks {
+		ids = append(ids, id)
+	}
+
+	sort.Strings(ids)
+
 	blocks := make([]brazeclient.ListContentBlocksResponseContentBlock, 0, len(h.contentBlocks))
-	for _, block := range h.contentBlocks {
+	for _, id := range ids {
+		block := h.contentBlocks[id]
 		blocks = append(blocks, brazeclient.ListContentBlocksResponseContentBlock{
 			ContentBlockID: block.ContentBlockID,
 			Name:           block.Name,
@@ -25,7 +34,7 @@ func (h *Handler) ListContentBlocks(_ context.Context, _ brazeclient.ListContent
 
 	return &brazeclient.ListContentBlocksResponse{
 		Count:         len(blocks),
-		ContentBlocks: blocks,
+		ContentBlocks: paginatedItems(blocks, params.Limit, params.Offset),
 	}, nil
 }
 

--- a/internal/braze-client-go/testing/pagination.go
+++ b/internal/braze-client-go/testing/pagination.go
@@ -1,0 +1,19 @@
+package testing
+
+import brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
+
+func paginatedItems[T any](items []T, limitOpt, offsetOpt brazeclient.OptInt) []T {
+	offset := offsetOpt.Or(0)
+	if offset >= len(items) {
+		return []T{}
+	}
+
+	limit, ok := limitOpt.Get()
+	if !ok || limit <= 0 {
+		return items[offset:]
+	}
+
+	end := min(offset+limit, len(items))
+
+	return items[offset:end]
+}

--- a/internal/provider/braze_content_block_list_resource.go
+++ b/internal/provider/braze_content_block_list_resource.go
@@ -32,6 +32,8 @@ type brazeContentBlockListResourceConfig struct {
 	ModifiedBefore timetypes.RFC3339 `tfsdk:"modified_before"`
 }
 
+const brazeContentBlockListPageLimit = 100
+
 func (r *brazeContentBlockListResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_content_block"
 }
@@ -67,8 +69,14 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 		return
 	}
 
+	if req.Limit <= 0 {
+		resp.Results = func(_ func(list.ListResult) bool) {}
+
+		return
+	}
+
 	params := brazeclient.ListContentBlocksParams{
-		Limit: brazeclient.NewOptInt(int(req.Limit)),
+		Limit: brazeclient.NewOptInt(brazeContentBlockListPageLimit),
 	}
 	paramsDiags := diag.Diagnostics{}
 
@@ -93,6 +101,25 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 	}
 
 	resp.Results = func(yield func(list.ListResult) bool) {
+		r.listContentBlocks(ctx, req, params, yield)
+	}
+}
+
+func (r *brazeContentBlockListResource) listContentBlocks(
+	ctx context.Context,
+	req list.ListRequest,
+	baseParams brazeclient.ListContentBlocksParams,
+	yield func(list.ListResult) bool,
+) {
+	offset := 0
+	remaining := req.Limit
+
+	for {
+		params := baseParams
+		if offset > 0 {
+			params.Offset = brazeclient.NewOptInt(offset)
+		}
+
 		listResponse, listErr := r.providerData.client.ListContentBlocks(ctx, params)
 
 		tflog.Info(ctx, "braze_content_block.list", map[string]any{
@@ -110,44 +137,75 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 			return
 		}
 
-		for _, block := range listResponse.GetContentBlocks() {
-			result := req.NewListResult(ctx)
-
-			result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("id"), block.GetContentBlockID())...)
-
-			result.DisplayName = block.GetName()
-
-			if req.IncludeResource {
-				params := brazeclient.GetContentBlockInfoParams{
-					ContentBlockID: block.GetContentBlockID(),
-				}
-
-				getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, params)
-
-				tflog.Info(ctx, "braze_content_block.list.get", map[string]any{
-					"params":   params,
-					"response": getResponse,
-					"err":      getErr,
-				})
-
-				if getResponse == nil || getErr != nil {
-					result.Diagnostics.AddError("Failed to get content block", detailFromError(getErr))
-
-					if !yield(result) {
-						return
-					}
-
-					continue
-				}
-
-				data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
-
-				result.Diagnostics.Append(result.Resource.Set(ctx, data)...)
-			}
-
-			if !yield(result) {
-				return
-			}
+		contentBlocks := listResponse.GetContentBlocks()
+		if !r.yieldContentBlockResults(ctx, req, contentBlocks, &remaining, yield) {
+			return
 		}
+
+		if remaining <= 0 || len(contentBlocks) < brazeContentBlockListPageLimit {
+			return
+		}
+
+		offset += brazeContentBlockListPageLimit
 	}
+}
+
+func (r *brazeContentBlockListResource) yieldContentBlockResults(
+	ctx context.Context,
+	req list.ListRequest,
+	contentBlocks []brazeclient.ListContentBlocksResponseContentBlock,
+	remaining *int64,
+	yield func(list.ListResult) bool,
+) bool {
+	for _, block := range contentBlocks {
+		if *remaining <= 0 {
+			return false
+		}
+
+		result := req.NewListResult(ctx)
+
+		result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("id"), block.GetContentBlockID())...)
+
+		result.DisplayName = block.GetName()
+
+		if req.IncludeResource {
+			r.setContentBlockResource(ctx, block, &result)
+		}
+
+		if !yield(result) {
+			return false
+		}
+
+		*remaining--
+	}
+
+	return true
+}
+
+func (r *brazeContentBlockListResource) setContentBlockResource(
+	ctx context.Context,
+	block brazeclient.ListContentBlocksResponseContentBlock,
+	result *list.ListResult,
+) {
+	params := brazeclient.GetContentBlockInfoParams{
+		ContentBlockID: block.GetContentBlockID(),
+	}
+
+	getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, params)
+
+	tflog.Info(ctx, "braze_content_block.list.get", map[string]any{
+		"params":   params,
+		"response": getResponse,
+		"err":      getErr,
+	})
+
+	if getResponse == nil || getErr != nil {
+		result.Diagnostics.AddError("Failed to get content block", detailFromError(getErr))
+
+		return
+	}
+
+	data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
+
+	result.Diagnostics.Append(result.Resource.Set(ctx, data)...)
 }

--- a/internal/provider/braze_content_block_list_resource_test.go
+++ b/internal/provider/braze_content_block_list_resource_test.go
@@ -1,10 +1,12 @@
 package provider_test
 
 import (
+	"fmt"
 	"testing"
 
 	brazeclienttesting "github.com/cysp/terraform-provider-braze/internal/braze-client-go/testing"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -41,6 +43,56 @@ func TestAccBrazeContentBlockList(t *testing.T) {
 					resource.TestCheckResourceAttr("braze_content_block.test", "content", "<p>This is <strong>HTML</strong> content</p>"),
 					resource.TestCheckResourceAttr("braze_content_block.test", "tags.#", "0"),
 				),
+			},
+			{
+				Query: true,
+				Config: `
+				provider "braze" {}
+
+				list "braze_content_block" "test" {
+					provider = braze
+
+					limit = 0
+				}
+				`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("braze_content_block.test", 0),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBrazeContentBlockListPagination(t *testing.T) {
+	t.Parallel()
+
+	server, _ := brazeclienttesting.NewBrazeServer()
+
+	for i := range 101 {
+		id := fmt.Sprintf("content-block-pagination-%03d", i)
+
+		server.SetContentBlock(id, id, "content", "", []string{})
+	}
+
+	BrazeProviderMockedResourceTest(t, server, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Query: true,
+				Config: `
+				provider "braze" {}
+
+				list "braze_content_block" "test" {
+					provider = braze
+
+					limit = 101
+				}
+				`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("braze_content_block.test", 101),
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- paginate content block list resources with provider-owned Braze page size
- avoid sending offset on the first Braze page request
- treat Terraform list limit as the maximum emitted result count, including limit = 0
- add mocked Braze pagination support and query coverage across the 100-item page boundary

## Testing
- go test ./...
- golangci-lint run