### PR TITLE
Refactor provider Braze object adapters

### DIFF
--- a/internal/provider/braze_content_block_adapter.go
+++ b/internal/provider/braze_content_block_adapter.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type contentBlockClient interface {
+	Create(ctx context.Context, plan brazeContentBlockModel) (brazeContentBlockModel, error)
+	Read(ctx context.Context, id string) (brazeContentBlockModel, error)
+	Update(ctx context.Context, plan brazeContentBlockModel) (brazeContentBlockModel, error)
+	List(ctx context.Context, query brazeObjectListQuery) ([]brazeObjectListEntry[brazeContentBlockModel], error)
+}
+
+type generatedContentBlockClient struct {
+	client *brazeclient.Client
+}
+
+type contentBlockListItem struct {
+	item brazeclient.ListContentBlocksResponseContentBlock
+}
+
+func newGeneratedContentBlockClient(client *brazeclient.Client) generatedContentBlockClient {
+	return generatedContentBlockClient{client: client}
+}
+
+func (c generatedContentBlockClient) Create(ctx context.Context, plan brazeContentBlockModel) (brazeContentBlockModel, error) {
+	createRequest := plan.ToCreateContentBlockRequest()
+
+	createResponse, createErr := c.client.CreateContentBlock(ctx, &createRequest)
+
+	tflog.Info(ctx, "braze_content_block.create", map[string]any{
+		"request":  createRequest,
+		"response": createResponse,
+		"err":      createErr,
+	})
+
+	if createErr != nil {
+		return brazeContentBlockModel{}, fmt.Errorf("create content block: %w", createErr)
+	}
+
+	if createResponse == nil {
+		return brazeContentBlockModel{}, errBrazeObjectEmptyResponse
+	}
+
+	return c.Read(ctx, createResponse.GetContentBlockID())
+}
+
+func (c generatedContentBlockClient) Read(ctx context.Context, id string) (brazeContentBlockModel, error) {
+	getParams := brazeclient.GetContentBlockInfoParams{
+		ContentBlockID: id,
+	}
+
+	getResponse, getErr := c.client.GetContentBlockInfo(ctx, getParams)
+
+	tflog.Info(ctx, "braze_content_block.read", map[string]any{
+		"params":   getParams,
+		"response": getResponse,
+		"err":      getErr,
+	})
+
+	if getErr != nil {
+		return brazeContentBlockModel{}, classifyBrazeObjectReadError(getErr)
+	}
+
+	if getResponse == nil {
+		return brazeContentBlockModel{}, errBrazeObjectEmptyResponse
+	}
+
+	return NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse), nil
+}
+
+func (c generatedContentBlockClient) Update(ctx context.Context, plan brazeContentBlockModel) (brazeContentBlockModel, error) {
+	updateRequest := plan.ToUpdateContentBlockRequest()
+
+	updateResponse, updateErr := c.client.UpdateContentBlock(ctx, &updateRequest)
+
+	tflog.Info(ctx, "braze_content_block.update", map[string]any{
+		"request":  updateRequest,
+		"response": updateResponse,
+		"err":      updateErr,
+	})
+
+	if updateErr != nil {
+		return brazeContentBlockModel{}, fmt.Errorf("update content block: %w", updateErr)
+	}
+
+	if updateResponse == nil {
+		return brazeContentBlockModel{}, errBrazeObjectEmptyResponse
+	}
+
+	return c.Read(ctx, updateResponse.GetContentBlockID())
+}
+
+func (c generatedContentBlockClient) List(ctx context.Context, query brazeObjectListQuery) ([]brazeObjectListEntry[brazeContentBlockModel], error) {
+	return listBrazeObjectEntries(query, func(offset, limit int) ([]contentBlockListItem, error) {
+		return c.listPage(ctx, query, offset, limit)
+	}, func(id string) (brazeContentBlockModel, error) {
+		return c.Read(ctx, id)
+	})
+}
+
+//nolint:dupl // The generated list endpoint types differ; abstracting this would add callback-heavy plumbing.
+func (c generatedContentBlockClient) listPage(ctx context.Context, query brazeObjectListQuery, offset, limit int) ([]contentBlockListItem, error) {
+	params := brazeclient.ListContentBlocksParams{}
+
+	applyBrazeObjectListQuery(
+		query,
+		offset,
+		limit,
+		func(value int) { params.Limit = brazeclient.NewOptInt(value) },
+		func(value int) { params.Offset = brazeclient.NewOptInt(value) },
+		func(value time.Time) { params.ModifiedAfter = brazeclient.NewOptDateTime(value) },
+		func(value time.Time) { params.ModifiedBefore = brazeclient.NewOptDateTime(value) },
+	)
+
+	listResponse, listErr := c.client.ListContentBlocks(ctx, params)
+
+	tflog.Info(ctx, "braze_content_block.list", map[string]any{
+		"params":   params,
+		"response": listResponse,
+		"err":      listErr,
+	})
+
+	if listErr != nil {
+		return nil, fmt.Errorf("list content blocks: %w", listErr)
+	}
+
+	if listResponse == nil {
+		return nil, errBrazeObjectEmptyResponse
+	}
+
+	contentBlocks := listResponse.GetContentBlocks()
+
+	items := make([]contentBlockListItem, len(contentBlocks))
+	for i, contentBlock := range contentBlocks {
+		items[i] = contentBlockListItem{item: contentBlock}
+	}
+
+	return items, nil
+}
+
+func (i contentBlockListItem) ListEntry() brazeObjectListEntry[brazeContentBlockModel] {
+	return brazeObjectListEntry[brazeContentBlockModel]{
+		ID:          i.item.GetContentBlockID(),
+		DisplayName: i.item.GetName(),
+	}
+}
+
+func classifyBrazeObjectReadError(err error) error {
+	var ersc *brazeclient.ErrorResponseStatusCode
+	if errors.As(err, &ersc) && ersc.StatusCode == http.StatusNotFound {
+		return brazeObjectNotFoundError{err: err}
+	}
+
+	return err
+}

--- a/internal/provider/braze_content_block_list_resource.go
+++ b/internal/provider/braze_content_block_list_resource.go
@@ -3,14 +3,12 @@ package provider
 import (
 	"context"
 
-	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 //nolint:ireturn
@@ -31,8 +29,6 @@ type brazeContentBlockListResourceConfig struct {
 	ModifiedAfter  timetypes.RFC3339 `tfsdk:"modified_after"`
 	ModifiedBefore timetypes.RFC3339 `tfsdk:"modified_before"`
 }
-
-const brazeContentBlockListPageLimit = 100
 
 func (r *brazeContentBlockListResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_content_block"
@@ -75,8 +71,9 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 		return
 	}
 
-	params := brazeclient.ListContentBlocksParams{
-		Limit: brazeclient.NewOptInt(brazeContentBlockListPageLimit),
+	query := brazeObjectListQuery{
+		Limit:           req.Limit,
+		IncludeResource: req.IncludeResource,
 	}
 	paramsDiags := diag.Diagnostics{}
 
@@ -84,14 +81,14 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 		modifiedAfter, modifiedAfterDiags := config.ModifiedAfter.ValueRFC3339Time()
 		paramsDiags.Append(modifiedAfterDiags...)
 
-		params.ModifiedAfter = brazeclient.NewOptDateTime(modifiedAfter)
+		query.ModifiedAfter = &modifiedAfter
 	}
 
 	if !config.ModifiedBefore.IsNull() {
 		modifiedBefore, modifiedBeforeDiags := config.ModifiedBefore.ValueRFC3339Time()
 		paramsDiags.Append(modifiedBeforeDiags...)
 
-		params.ModifiedBefore = brazeclient.NewOptDateTime(modifiedBefore)
+		query.ModifiedBefore = &modifiedBefore
 	}
 
 	if paramsDiags.HasError() {
@@ -101,111 +98,43 @@ func (r *brazeContentBlockListResource) List(ctx context.Context, req list.ListR
 	}
 
 	resp.Results = func(yield func(list.ListResult) bool) {
-		r.listContentBlocks(ctx, req, params, yield)
+		r.listContentBlocks(ctx, req, query, yield)
 	}
 }
 
 func (r *brazeContentBlockListResource) listContentBlocks(
 	ctx context.Context,
 	req list.ListRequest,
-	baseParams brazeclient.ListContentBlocksParams,
+	query brazeObjectListQuery,
 	yield func(list.ListResult) bool,
 ) {
-	offset := 0
-	remaining := req.Limit
-
-	for {
-		params := baseParams
-		if offset > 0 {
-			params.Offset = brazeclient.NewOptInt(offset)
-		}
-
-		listResponse, listErr := r.providerData.client.ListContentBlocks(ctx, params)
-
-		tflog.Info(ctx, "braze_content_block.list", map[string]any{
-			"params":   params,
-			"response": listResponse,
-			"err":      listErr,
-		})
-
-		if listErr != nil {
-			result := req.NewListResult(ctx)
-			result.Diagnostics.AddError("Failed to list content blocks", listErr.Error())
-
-			yield(result)
-
-			return
-		}
-
-		contentBlocks := listResponse.GetContentBlocks()
-		if !r.yieldContentBlockResults(ctx, req, contentBlocks, &remaining, yield) {
-			return
-		}
-
-		if remaining <= 0 || len(contentBlocks) < brazeContentBlockListPageLimit {
-			return
-		}
-
-		offset += brazeContentBlockListPageLimit
-	}
-}
-
-func (r *brazeContentBlockListResource) yieldContentBlockResults(
-	ctx context.Context,
-	req list.ListRequest,
-	contentBlocks []brazeclient.ListContentBlocksResponseContentBlock,
-	remaining *int64,
-	yield func(list.ListResult) bool,
-) bool {
-	for _, block := range contentBlocks {
-		if *remaining <= 0 {
-			return false
-		}
-
+	entries, listErr := r.providerData.contentBlocks.List(ctx, query)
+	if listErr != nil {
 		result := req.NewListResult(ctx)
+		result.Diagnostics.AddError("Failed to list content blocks", detailFromError(listErr))
 
-		result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("id"), block.GetContentBlockID())...)
-
-		result.DisplayName = block.GetName()
-
-		if req.IncludeResource {
-			r.setContentBlockResource(ctx, block, &result)
-		}
-
-		if !yield(result) {
-			return false
-		}
-
-		*remaining--
-	}
-
-	return true
-}
-
-func (r *brazeContentBlockListResource) setContentBlockResource(
-	ctx context.Context,
-	block brazeclient.ListContentBlocksResponseContentBlock,
-	result *list.ListResult,
-) {
-	params := brazeclient.GetContentBlockInfoParams{
-		ContentBlockID: block.GetContentBlockID(),
-	}
-
-	getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, params)
-
-	tflog.Info(ctx, "braze_content_block.list.get", map[string]any{
-		"params":   params,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		result.Diagnostics.AddError("Failed to get content block", detailFromError(getErr))
+		yield(result)
 
 		return
 	}
 
-	data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
+	for _, entry := range entries {
+		result := req.NewListResult(ctx)
 
-	result.Diagnostics.Append(result.Resource.Set(ctx, data)...)
+		result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("id"), entry.ID)...)
+
+		result.DisplayName = entry.DisplayName
+
+		if req.IncludeResource {
+			if entry.ResourceErr != nil {
+				result.Diagnostics.AddError("Failed to get content block", detailFromError(entry.ResourceErr))
+			} else {
+				result.Diagnostics.Append(result.Resource.Set(ctx, *entry.Resource)...)
+			}
+		}
+
+		if !yield(result) {
+			return
+		}
+	}
 }

--- a/internal/provider/braze_content_block_list_resource_test.go
+++ b/internal/provider/braze_content_block_list_resource_test.go
@@ -6,7 +6,9 @@ import (
 
 	brazeclienttesting "github.com/cysp/terraform-provider-braze/internal/braze-client-go/testing"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck/queryfilter"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -43,6 +45,31 @@ func TestAccBrazeContentBlockList(t *testing.T) {
 					resource.TestCheckResourceAttr("braze_content_block.test", "content", "<p>This is <strong>HTML</strong> content</p>"),
 					resource.TestCheckResourceAttr("braze_content_block.test", "tags.#", "0"),
 				),
+			},
+			{
+				Query: true,
+				Config: `
+				provider "braze" {}
+
+				list "braze_content_block" "test" {
+					provider = braze
+
+					limit = 1
+				}
+				`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("braze_content_block.test", 1),
+					querycheck.ExpectIdentity("braze_content_block.test", map[string]knownvalue.Check{
+						"id": knownvalue.StringExact("content-block-id"),
+					}),
+					querycheck.ExpectResourceDisplayName(
+						"braze_content_block.test",
+						queryfilter.ByResourceIdentity(map[string]knownvalue.Check{
+							"id": knownvalue.StringExact("content-block-id"),
+						}),
+						knownvalue.StringExact("test-content-block"),
+					),
+				},
 			},
 			{
 				Query: true,

--- a/internal/provider/braze_content_block_resource.go
+++ b/internal/provider/braze_content_block_resource.go
@@ -2,13 +2,9 @@ package provider
 
 import (
 	"context"
-	"errors"
-	"net/http"
 
-	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -55,55 +51,18 @@ func (r *brazeContentBlockResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	createRequest := plan.ToCreateContentBlockRequest()
-
-	createResponse, createErr := r.providerData.client.CreateContentBlock(ctx, &createRequest)
-
-	tflog.Info(ctx, "braze_content_block.create", map[string]any{
-		"request":  createRequest,
-		"response": createResponse,
-		"err":      createErr,
-	})
-
-	if createResponse == nil || createErr != nil {
-		resp.Diagnostics.AddError("Failed to create Content Block", detailFromError(createErr))
-
-		return
-	}
-
-	contentBlockID := createResponse.GetContentBlockID()
-
-	resp.Diagnostics.Append(setIdentity(ctx, resp.Identity, &resp.State, contentBlockID)...)
-
-	getParams := brazeclient.GetContentBlockInfoParams{
-		ContentBlockID: contentBlockID,
-	}
-
-	getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_content_block.create.get", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddError("Content Block not found after creation", ersc.Error())
-
-			return
+	data, err := r.providerData.contentBlocks.Create(ctx, plan)
+	if err != nil {
+		if isBrazeObjectNotFound(err) {
+			resp.Diagnostics.AddError("Content Block not found after creation", detailFromError(err))
+		} else {
+			resp.Diagnostics.AddError("Failed to create Content Block", detailFromError(err))
 		}
 
-		resp.Diagnostics.AddError("Failed to retrieve Content Block after creation", detailFromError(getErr))
-
 		return
 	}
 
-	contentBlockID = getResponse.GetContentBlockID()
-	data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, contentBlockID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeContentBlockResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -115,36 +74,21 @@ func (r *brazeContentBlockResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	getParams := brazeclient.GetContentBlockInfoParams{
-		ContentBlockID: state.ID.ValueString(),
-	}
-
-	getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_content_block.read", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddWarning("Content Block not found", ersc.Error())
+	data, err := r.providerData.contentBlocks.Read(ctx, state.ID.ValueString())
+	if err != nil {
+		if isBrazeObjectNotFound(err) {
+			resp.Diagnostics.AddWarning("Content Block not found", detailFromError(err))
 			resp.State.RemoveResource(ctx)
 
 			return
 		}
 
-		resp.Diagnostics.AddError("Failed to read Content Block", detailFromError(getErr))
+		resp.Diagnostics.AddError("Failed to read Content Block", detailFromError(err))
 
 		return
 	}
 
-	contentBlockID := getResponse.GetContentBlockID()
-	data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, contentBlockID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeContentBlockResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -156,55 +100,18 @@ func (r *brazeContentBlockResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	updateRequest := plan.ToUpdateContentBlockRequest()
-
-	updateResponse, updateErr := r.providerData.client.UpdateContentBlock(ctx, &updateRequest)
-
-	tflog.Info(ctx, "braze_content_block.update", map[string]any{
-		"request":  updateRequest,
-		"response": updateResponse,
-		"err":      updateErr,
-	})
-
-	if updateResponse == nil || updateErr != nil {
-		resp.Diagnostics.AddError("Failed to update Content Block", detailFromError(updateErr))
-
-		return
-	}
-
-	contentBlockID := updateResponse.GetContentBlockID()
-
-	resp.Diagnostics.Append(setIdentity(ctx, resp.Identity, &resp.State, contentBlockID)...)
-
-	getParams := brazeclient.GetContentBlockInfoParams{
-		ContentBlockID: contentBlockID,
-	}
-
-	getResponse, getErr := r.providerData.client.GetContentBlockInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_content_block.update.get", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddError("Content Block not found after update", ersc.Error())
-
-			return
+	data, err := r.providerData.contentBlocks.Update(ctx, plan)
+	if err != nil {
+		if isBrazeObjectNotFound(err) {
+			resp.Diagnostics.AddError("Content Block not found after update", detailFromError(err))
+		} else {
+			resp.Diagnostics.AddError("Failed to update Content Block", detailFromError(err))
 		}
 
-		resp.Diagnostics.AddError("Failed to retrieve Content Block after update", detailFromError(getErr))
-
 		return
 	}
 
-	contentBlockID = getResponse.GetContentBlockID()
-	data := NewBrazeContentBlockModelFromGetContentBlockInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, contentBlockID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeContentBlockResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/braze_email_template_adapter.go
+++ b/internal/provider/braze_email_template_adapter.go
@@ -1,0 +1,152 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type emailTemplateClient interface {
+	Create(ctx context.Context, plan brazeEmailTemplateModel) (brazeEmailTemplateModel, error)
+	Read(ctx context.Context, id string) (brazeEmailTemplateModel, error)
+	Update(ctx context.Context, plan brazeEmailTemplateModel) (brazeEmailTemplateModel, error)
+	List(ctx context.Context, query brazeObjectListQuery) ([]brazeObjectListEntry[brazeEmailTemplateModel], error)
+}
+
+type generatedEmailTemplateClient struct {
+	client *brazeclient.Client
+}
+
+type emailTemplateListItem struct {
+	item brazeclient.ListEmailTemplatesResponseTemplatesItem
+}
+
+func newGeneratedEmailTemplateClient(client *brazeclient.Client) generatedEmailTemplateClient {
+	return generatedEmailTemplateClient{client: client}
+}
+
+func (c generatedEmailTemplateClient) Create(ctx context.Context, plan brazeEmailTemplateModel) (brazeEmailTemplateModel, error) {
+	createRequest := plan.ToCreateEmailTemplateRequest()
+
+	createResponse, createErr := c.client.CreateEmailTemplate(ctx, &createRequest)
+
+	tflog.Info(ctx, "braze_email_template.create", map[string]any{
+		"request":  createRequest,
+		"response": createResponse,
+		"err":      createErr,
+	})
+
+	if createErr != nil {
+		return brazeEmailTemplateModel{}, fmt.Errorf("create email template: %w", createErr)
+	}
+
+	if createResponse == nil {
+		return brazeEmailTemplateModel{}, errBrazeObjectEmptyResponse
+	}
+
+	return c.Read(ctx, createResponse.GetEmailTemplateID())
+}
+
+func (c generatedEmailTemplateClient) Read(ctx context.Context, id string) (brazeEmailTemplateModel, error) {
+	getParams := brazeclient.GetEmailTemplateInfoParams{
+		EmailTemplateID: id,
+	}
+
+	getResponse, getErr := c.client.GetEmailTemplateInfo(ctx, getParams)
+
+	tflog.Info(ctx, "braze_email_template.read", map[string]any{
+		"params":   getParams,
+		"response": getResponse,
+		"err":      getErr,
+	})
+
+	if getErr != nil {
+		return brazeEmailTemplateModel{}, classifyBrazeObjectReadError(getErr)
+	}
+
+	if getResponse == nil {
+		return brazeEmailTemplateModel{}, errBrazeObjectEmptyResponse
+	}
+
+	return NewBrazeEmailTemplateModelFromGetEmailTemplateInfoResponse(*getResponse), nil
+}
+
+func (c generatedEmailTemplateClient) Update(ctx context.Context, plan brazeEmailTemplateModel) (brazeEmailTemplateModel, error) {
+	updateRequest := plan.ToUpdateEmailTemplateRequest()
+
+	updateResponse, updateErr := c.client.UpdateEmailTemplate(ctx, &updateRequest)
+
+	tflog.Info(ctx, "braze_email_template.update", map[string]any{
+		"request":  updateRequest,
+		"response": updateResponse,
+		"err":      updateErr,
+	})
+
+	if updateErr != nil {
+		return brazeEmailTemplateModel{}, fmt.Errorf("update email template: %w", updateErr)
+	}
+
+	if updateResponse == nil {
+		return brazeEmailTemplateModel{}, errBrazeObjectEmptyResponse
+	}
+
+	return c.Read(ctx, updateResponse.GetEmailTemplateID())
+}
+
+func (c generatedEmailTemplateClient) List(ctx context.Context, query brazeObjectListQuery) ([]brazeObjectListEntry[brazeEmailTemplateModel], error) {
+	return listBrazeObjectEntries(query, func(offset, limit int) ([]emailTemplateListItem, error) {
+		return c.listPage(ctx, query, offset, limit)
+	}, func(id string) (brazeEmailTemplateModel, error) {
+		return c.Read(ctx, id)
+	})
+}
+
+//nolint:dupl // The generated list endpoint types differ; abstracting this would add callback-heavy plumbing.
+func (c generatedEmailTemplateClient) listPage(ctx context.Context, query brazeObjectListQuery, offset, limit int) ([]emailTemplateListItem, error) {
+	params := brazeclient.ListEmailTemplatesParams{}
+
+	applyBrazeObjectListQuery(
+		query,
+		offset,
+		limit,
+		func(value int) { params.Limit = brazeclient.NewOptInt(value) },
+		func(value int) { params.Offset = brazeclient.NewOptInt(value) },
+		func(value time.Time) { params.ModifiedAfter = brazeclient.NewOptDateTime(value) },
+		func(value time.Time) { params.ModifiedBefore = brazeclient.NewOptDateTime(value) },
+	)
+
+	listResponse, listErr := c.client.ListEmailTemplates(ctx, params)
+
+	tflog.Info(ctx, "braze_email_template.list", map[string]any{
+		"params":   params,
+		"response": listResponse,
+		"err":      listErr,
+	})
+
+	if listErr != nil {
+		return nil, fmt.Errorf("list email templates: %w", listErr)
+	}
+
+	if listResponse == nil {
+		return nil, errBrazeObjectEmptyResponse
+	}
+
+	emailTemplates := listResponse.GetTemplates()
+
+	items := make([]emailTemplateListItem, len(emailTemplates))
+	for i, emailTemplate := range emailTemplates {
+		items[i] = emailTemplateListItem{item: emailTemplate}
+	}
+
+	return items, nil
+}
+
+func (i emailTemplateListItem) ListEntry() brazeObjectListEntry[brazeEmailTemplateModel] {
+	return brazeObjectListEntry[brazeEmailTemplateModel]{
+		ID:          i.item.GetEmailTemplateID(),
+		DisplayName: i.item.GetTemplateName(),
+	}
+}

--- a/internal/provider/braze_email_template_list_resource.go
+++ b/internal/provider/braze_email_template_list_resource.go
@@ -3,14 +3,12 @@ package provider
 import (
 	"context"
 
-	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 //nolint:ireturn
@@ -31,8 +29,6 @@ type brazeEmailTemplateListResourceConfig struct {
 	ModifiedAfter  timetypes.RFC3339 `tfsdk:"modified_after"`
 	ModifiedBefore timetypes.RFC3339 `tfsdk:"modified_before"`
 }
-
-const brazeEmailTemplateListPageLimit = 100
 
 func (r *brazeEmailTemplateListResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_email_template"
@@ -75,8 +71,9 @@ func (r *brazeEmailTemplateListResource) List(ctx context.Context, req list.List
 		return
 	}
 
-	params := brazeclient.ListEmailTemplatesParams{
-		Limit: brazeclient.NewOptInt(brazeEmailTemplateListPageLimit),
+	query := brazeObjectListQuery{
+		Limit:           req.Limit,
+		IncludeResource: req.IncludeResource,
 	}
 	paramsDiags := diag.Diagnostics{}
 
@@ -84,14 +81,14 @@ func (r *brazeEmailTemplateListResource) List(ctx context.Context, req list.List
 		modifiedAfter, modifiedAfterDiags := config.ModifiedAfter.ValueRFC3339Time()
 		paramsDiags.Append(modifiedAfterDiags...)
 
-		params.ModifiedAfter = brazeclient.NewOptDateTime(modifiedAfter)
+		query.ModifiedAfter = &modifiedAfter
 	}
 
 	if !config.ModifiedBefore.IsNull() {
 		modifiedBefore, modifiedBeforeDiags := config.ModifiedBefore.ValueRFC3339Time()
 		paramsDiags.Append(modifiedBeforeDiags...)
 
-		params.ModifiedBefore = brazeclient.NewOptDateTime(modifiedBefore)
+		query.ModifiedBefore = &modifiedBefore
 	}
 
 	if paramsDiags.HasError() {
@@ -101,111 +98,43 @@ func (r *brazeEmailTemplateListResource) List(ctx context.Context, req list.List
 	}
 
 	resp.Results = func(yield func(list.ListResult) bool) {
-		r.listEmailTemplates(ctx, req, params, yield)
+		r.listEmailTemplates(ctx, req, query, yield)
 	}
 }
 
 func (r *brazeEmailTemplateListResource) listEmailTemplates(
 	ctx context.Context,
 	req list.ListRequest,
-	baseParams brazeclient.ListEmailTemplatesParams,
+	query brazeObjectListQuery,
 	yield func(list.ListResult) bool,
 ) {
-	offset := 0
-	remaining := req.Limit
-
-	for {
-		params := baseParams
-		if offset > 0 {
-			params.Offset = brazeclient.NewOptInt(offset)
-		}
-
-		listResponse, listErr := r.providerData.client.ListEmailTemplates(ctx, params)
-
-		tflog.Info(ctx, "braze_email_template.list", map[string]any{
-			"params":   params,
-			"response": listResponse,
-			"err":      listErr,
-		})
-
-		if listErr != nil {
-			result := req.NewListResult(ctx)
-			result.Diagnostics.AddError("Failed to list email templates", listErr.Error())
-
-			yield(result)
-
-			return
-		}
-
-		emailTemplates := listResponse.GetTemplates()
-		if !r.yieldEmailTemplateResults(ctx, req, emailTemplates, &remaining, yield) {
-			return
-		}
-
-		if remaining <= 0 || len(emailTemplates) < brazeEmailTemplateListPageLimit {
-			return
-		}
-
-		offset += brazeEmailTemplateListPageLimit
-	}
-}
-
-func (r *brazeEmailTemplateListResource) yieldEmailTemplateResults(
-	ctx context.Context,
-	req list.ListRequest,
-	emailTemplates []brazeclient.ListEmailTemplatesResponseTemplatesItem,
-	remaining *int64,
-	yield func(list.ListResult) bool,
-) bool {
-	for _, template := range emailTemplates {
-		if *remaining <= 0 {
-			return false
-		}
-
+	entries, listErr := r.providerData.emailTemplates.List(ctx, query)
+	if listErr != nil {
 		result := req.NewListResult(ctx)
+		result.Diagnostics.AddError("Failed to list email templates", detailFromError(listErr))
 
-		result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("id"), template.GetEmailTemplateID())...)
-
-		result.DisplayName = template.GetTemplateName()
-
-		if req.IncludeResource {
-			r.setEmailTemplateResource(ctx, template, &result)
-		}
-
-		if !yield(result) {
-			return false
-		}
-
-		*remaining--
-	}
-
-	return true
-}
-
-func (r *brazeEmailTemplateListResource) setEmailTemplateResource(
-	ctx context.Context,
-	template brazeclient.ListEmailTemplatesResponseTemplatesItem,
-	result *list.ListResult,
-) {
-	params := brazeclient.GetEmailTemplateInfoParams{
-		EmailTemplateID: template.GetEmailTemplateID(),
-	}
-
-	getResponse, getErr := r.providerData.client.GetEmailTemplateInfo(ctx, params)
-
-	tflog.Info(ctx, "braze_email_template.list.get", map[string]any{
-		"params":   params,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		result.Diagnostics.AddError("Failed to get email template", detailFromError(getErr))
+		yield(result)
 
 		return
 	}
 
-	data := NewBrazeEmailTemplateModelFromGetEmailTemplateInfoResponse(*getResponse)
+	for _, entry := range entries {
+		result := req.NewListResult(ctx)
 
-	result.Diagnostics.Append(result.Resource.Set(ctx, data)...)
+		result.Diagnostics.Append(result.Identity.SetAttribute(ctx, path.Root("id"), entry.ID)...)
+
+		result.DisplayName = entry.DisplayName
+
+		if req.IncludeResource {
+			if entry.ResourceErr != nil {
+				result.Diagnostics.AddError("Failed to get email template", detailFromError(entry.ResourceErr))
+			} else {
+				result.Diagnostics.Append(result.Resource.Set(ctx, *entry.Resource)...)
+			}
+		}
+
+		if !yield(result) {
+			return
+		}
+	}
 }

--- a/internal/provider/braze_email_template_list_resource_test.go
+++ b/internal/provider/braze_email_template_list_resource_test.go
@@ -6,7 +6,9 @@ import (
 
 	brazeclienttesting "github.com/cysp/terraform-provider-braze/internal/braze-client-go/testing"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck/queryfilter"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -48,6 +50,31 @@ func TestAccBrazeEmailTemplateList(t *testing.T) {
 					resource.TestCheckResourceAttr("braze_email_template.test", "tags.0", "tag1"),
 					resource.TestCheckResourceAttr("braze_email_template.test", "should_inline_css", "true"),
 				),
+			},
+			{
+				Query: true,
+				Config: `
+				provider "braze" {}
+
+				list "braze_email_template" "test" {
+					provider = braze
+
+					limit = 1
+				}
+				`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("braze_email_template.test", 1),
+					querycheck.ExpectIdentity("braze_email_template.test", map[string]knownvalue.Check{
+						"id": knownvalue.StringExact("email-template-id"),
+					}),
+					querycheck.ExpectResourceDisplayName(
+						"braze_email_template.test",
+						queryfilter.ByResourceIdentity(map[string]knownvalue.Check{
+							"id": knownvalue.StringExact("email-template-id"),
+						}),
+						knownvalue.StringExact("test-email-template"),
+					),
+				},
 			},
 			{
 				Query: true,

--- a/internal/provider/braze_email_template_resource.go
+++ b/internal/provider/braze_email_template_resource.go
@@ -2,13 +2,9 @@ package provider
 
 import (
 	"context"
-	"errors"
-	"net/http"
 
-	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -55,55 +51,18 @@ func (r *brazeEmailTemplateResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	createRequest := plan.ToCreateEmailTemplateRequest()
-
-	createResponse, createErr := r.providerData.client.CreateEmailTemplate(ctx, &createRequest)
-
-	tflog.Info(ctx, "braze_email_template.create", map[string]any{
-		"request":  createRequest,
-		"response": createResponse,
-		"err":      createErr,
-	})
-
-	if createResponse == nil || createErr != nil {
-		resp.Diagnostics.AddError("Failed to create Email Template", detailFromError(createErr))
-
-		return
-	}
-
-	emailTemplateID := createResponse.GetEmailTemplateID()
-
-	resp.Diagnostics.Append(setIdentity(ctx, resp.Identity, &resp.State, emailTemplateID)...)
-
-	getParams := brazeclient.GetEmailTemplateInfoParams{
-		EmailTemplateID: emailTemplateID,
-	}
-
-	getResponse, getErr := r.providerData.client.GetEmailTemplateInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_email_template.create.get", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddError("Email Template not found after creation", ersc.Error())
-
-			return
+	data, err := r.providerData.emailTemplates.Create(ctx, plan)
+	if err != nil {
+		if isBrazeObjectNotFound(err) {
+			resp.Diagnostics.AddError("Email Template not found after creation", detailFromError(err))
+		} else {
+			resp.Diagnostics.AddError("Failed to create Email Template", detailFromError(err))
 		}
 
-		resp.Diagnostics.AddError("Failed to retrieve Email Template after creation", detailFromError(getErr))
-
 		return
 	}
 
-	emailTemplateID = getResponse.GetEmailTemplateID()
-	data := NewBrazeEmailTemplateModelFromGetEmailTemplateInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, emailTemplateID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeEmailTemplateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -115,36 +74,21 @@ func (r *brazeEmailTemplateResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	getParams := brazeclient.GetEmailTemplateInfoParams{
-		EmailTemplateID: state.ID.ValueString(),
-	}
-
-	getResponse, getErr := r.providerData.client.GetEmailTemplateInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_email_template.read", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddWarning("Email Template not found", ersc.Error())
+	data, err := r.providerData.emailTemplates.Read(ctx, state.ID.ValueString())
+	if err != nil {
+		if isBrazeObjectNotFound(err) {
+			resp.Diagnostics.AddWarning("Email Template not found", detailFromError(err))
 			resp.State.RemoveResource(ctx)
 
 			return
 		}
 
-		resp.Diagnostics.AddError("Failed to read Email Template", detailFromError(getErr))
+		resp.Diagnostics.AddError("Failed to read Email Template", detailFromError(err))
 
 		return
 	}
 
-	emailTemplateID := getResponse.GetEmailTemplateID()
-	data := NewBrazeEmailTemplateModelFromGetEmailTemplateInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, emailTemplateID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeEmailTemplateResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -155,55 +99,18 @@ func (r *brazeEmailTemplateResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	updateRequest := plan.ToUpdateEmailTemplateRequest()
-
-	updateResponse, updateErr := r.providerData.client.UpdateEmailTemplate(ctx, &updateRequest)
-
-	tflog.Info(ctx, "braze_email_template.update", map[string]any{
-		"request":  updateRequest,
-		"response": updateResponse,
-		"err":      updateErr,
-	})
-
-	if updateResponse == nil || updateErr != nil {
-		resp.Diagnostics.AddError("Failed to update Email Template", detailFromError(updateErr))
-
-		return
-	}
-
-	emailTemplateID := updateResponse.GetEmailTemplateID()
-
-	resp.Diagnostics.Append(setIdentity(ctx, resp.Identity, &resp.State, emailTemplateID)...)
-
-	getParams := brazeclient.GetEmailTemplateInfoParams{
-		EmailTemplateID: emailTemplateID,
-	}
-
-	getResponse, getErr := r.providerData.client.GetEmailTemplateInfo(ctx, getParams)
-
-	tflog.Info(ctx, "braze_email_template.update.get", map[string]any{
-		"params":   getParams,
-		"response": getResponse,
-		"err":      getErr,
-	})
-
-	if getResponse == nil || getErr != nil {
-		var ersc *brazeclient.ErrorResponseStatusCode
-		if errors.As(getErr, &ersc) && ersc.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddError("Email Template not found after update", ersc.Error())
-
-			return
+	data, err := r.providerData.emailTemplates.Update(ctx, plan)
+	if err != nil {
+		if isBrazeObjectNotFound(err) {
+			resp.Diagnostics.AddError("Email Template not found after update", detailFromError(err))
+		} else {
+			resp.Diagnostics.AddError("Failed to update Email Template", detailFromError(err))
 		}
 
-		resp.Diagnostics.AddError("Failed to retrieve Email Template after update", detailFromError(getErr))
-
 		return
 	}
 
-	emailTemplateID = getResponse.GetEmailTemplateID()
-	data := NewBrazeEmailTemplateModelFromGetEmailTemplateInfoResponse(*getResponse)
-
-	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, emailTemplateID, &data)...)
+	resp.Diagnostics.Append(setIdentityAndState(ctx, resp.Identity, &resp.State, data.ID.ValueString(), &data)...)
 }
 
 func (r *brazeEmailTemplateResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/braze_object_adapter.go
+++ b/internal/provider/braze_object_adapter.go
@@ -1,0 +1,139 @@
+package provider
+
+import (
+	"errors"
+	"time"
+)
+
+const brazeObjectListPageLimit = 100
+
+var errBrazeObjectEmptyResponse = errors.New("empty Braze object response")
+
+type brazeObjectListQuery struct {
+	Limit           int64
+	ModifiedAfter   *time.Time
+	ModifiedBefore  *time.Time
+	IncludeResource bool
+}
+
+type brazeObjectListEntry[Model any] struct {
+	ID          string
+	DisplayName string
+	Resource    *Model
+	ResourceErr error
+}
+
+type brazeObjectListItem[Model any] interface {
+	ListEntry() brazeObjectListEntry[Model]
+}
+
+type brazeObjectNotFoundError struct {
+	err error
+}
+
+func (e brazeObjectNotFoundError) Error() string {
+	return e.err.Error()
+}
+
+func (e brazeObjectNotFoundError) Unwrap() error {
+	return e.err
+}
+
+func isBrazeObjectNotFound(err error) bool {
+	var notFound brazeObjectNotFoundError
+
+	return errors.As(err, &notFound)
+}
+
+func collectBrazeObjectPages[Item any](query brazeObjectListQuery, fetch func(offset, limit int) ([]Item, error)) ([]Item, error) {
+	if query.Limit <= 0 {
+		return nil, nil
+	}
+
+	offset := 0
+	remaining := query.Limit
+	items := make([]Item, 0, min(int(query.Limit), brazeObjectListPageLimit))
+
+	for {
+		page, err := fetch(offset, brazeObjectListPageLimit)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range page {
+			if remaining <= 0 {
+				return items, nil
+			}
+
+			items = append(items, item)
+			remaining--
+		}
+
+		if remaining <= 0 || len(page) < brazeObjectListPageLimit {
+			return items, nil
+		}
+
+		offset += brazeObjectListPageLimit
+	}
+}
+
+func buildBrazeObjectListEntries[Item brazeObjectListItem[Model], Model any](
+	query brazeObjectListQuery,
+	items []Item,
+	read func(id string) (Model, error),
+) []brazeObjectListEntry[Model] {
+	entries := make([]brazeObjectListEntry[Model], 0, len(items))
+	for _, item := range items {
+		entry := item.ListEntry()
+
+		if query.IncludeResource {
+			resource, err := read(entry.ID)
+			if err != nil {
+				entry.ResourceErr = err
+			} else {
+				entry.Resource = &resource
+			}
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+func listBrazeObjectEntries[Item brazeObjectListItem[Model], Model any](
+	query brazeObjectListQuery,
+	fetch func(offset, limit int) ([]Item, error),
+	read func(id string) (Model, error),
+) ([]brazeObjectListEntry[Model], error) {
+	items, err := collectBrazeObjectPages(query, fetch)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildBrazeObjectListEntries(query, items, read), nil
+}
+
+func applyBrazeObjectListQuery(
+	query brazeObjectListQuery,
+	offset int,
+	limit int,
+	setLimit func(int),
+	setOffset func(int),
+	setModifiedAfter func(time.Time),
+	setModifiedBefore func(time.Time),
+) {
+	setLimit(limit)
+
+	if offset > 0 {
+		setOffset(offset)
+	}
+
+	if query.ModifiedAfter != nil {
+		setModifiedAfter(*query.ModifiedAfter)
+	}
+
+	if query.ModifiedBefore != nil {
+		setModifiedBefore(*query.ModifiedBefore)
+	}
+}

--- a/internal/provider/braze_object_adapter_test.go
+++ b/internal/provider/braze_object_adapter_test.go
@@ -1,0 +1,245 @@
+//nolint:testpackage
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
+	brazeclienttesting "github.com/cysp/terraform-provider-braze/internal/braze-client-go/testing"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errTestBrazeObjectFetch = errors.New("fetch failed")
+
+func TestCollectBrazeObjectPages(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		query         brazeObjectListQuery
+		fetch         func(offset, limit int) ([]string, error)
+		expectedItems []string
+		expectedCalls []string
+		expectedErr   error
+	}{
+		"zero limit does not fetch": {
+			query: brazeObjectListQuery{Limit: 0},
+			fetch: func(int, int) ([]string, error) {
+				t.Fatal("fetch should not be called")
+
+				return nil, nil
+			},
+		},
+		"stops after short page": {
+			query: brazeObjectListQuery{Limit: 100},
+			fetch: func(offset, limit int) ([]string, error) {
+				return []string{fmt.Sprintf("%d/%d", offset, limit)}, nil
+			},
+			expectedItems: []string{"0/100"},
+			expectedCalls: []string{"0/100"},
+		},
+		"fetches until requested limit": {
+			query: brazeObjectListQuery{Limit: 101},
+			fetch: func(offset, limit int) ([]string, error) {
+				items := make([]string, limit)
+				for i := range items {
+					items[i] = strconv.Itoa(offset + i)
+				}
+
+				return items, nil
+			},
+			expectedItems: makeRangeStrings(101),
+			expectedCalls: []string{"0/100", "100/100"},
+		},
+		"returns fetch error": {
+			query: brazeObjectListQuery{Limit: 101},
+			fetch: func(offset, limit int) ([]string, error) {
+				if offset == 100 {
+					return nil, errTestBrazeObjectFetch
+				}
+
+				return makeRangeStrings(limit), nil
+			},
+			expectedItems: nil,
+			expectedCalls: []string{"0/100", "100/100"},
+			expectedErr:   errTestBrazeObjectFetch,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls []string
+
+			actual, err := collectBrazeObjectPages(test.query, func(offset, limit int) ([]string, error) {
+				calls = append(calls, fmt.Sprintf("%d/%d", offset, limit))
+
+				return test.fetch(offset, limit)
+			})
+
+			if test.expectedErr != nil {
+				require.ErrorIs(t, err, test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, test.expectedItems, actual)
+			assert.Equal(t, test.expectedCalls, calls)
+		})
+	}
+}
+
+func TestGeneratedContentBlockClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read maps not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedContentBlockClient(newTestBrazeClient(t, func(*brazeclienttesting.Server) {}))
+
+		_, err := client.Read(t.Context(), "missing-content-block")
+
+		require.Error(t, err)
+		assert.True(t, isBrazeObjectNotFound(err))
+	})
+
+	t.Run("create returns hydrated model", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedContentBlockClient(newTestBrazeClient(t, func(*brazeclienttesting.Server) {}))
+
+		actual, err := client.Create(t.Context(), brazeContentBlockModel{
+			Name:        types.StringValue("Created content block"),
+			Description: types.StringValue("created description"),
+			Content:     types.StringValue("<p>Created</p>"),
+			Tags:        NewTypedListFromStringSlice([]string{"tag2"}),
+		})
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, actual.ID.ValueString())
+		assert.Equal(t, "Created content block", actual.Name.ValueString())
+		assert.Equal(t, "created description", actual.Description.ValueString())
+		assert.Equal(t, "<p>Created</p>", actual.Content.ValueString())
+		assert.Equal(t, []string{"tag2"}, TypedListToStringSlice(actual.Tags))
+	})
+
+	t.Run("list hydrates resources", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedContentBlockClient(newTestBrazeClient(t, func(server *brazeclienttesting.Server) {
+			server.SetContentBlock("existing-content-block", "Existing content block", "<p>Existing</p>", "description", []string{"tag1"})
+		}))
+
+		entries, err := client.List(t.Context(), brazeObjectListQuery{
+			Limit:           1,
+			IncludeResource: true,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "existing-content-block", entries[0].ID)
+		assert.Equal(t, "Existing content block", entries[0].DisplayName)
+		require.NotNil(t, entries[0].Resource)
+		assert.Equal(t, "<p>Existing</p>", entries[0].Resource.Content.ValueString())
+		assert.NoError(t, entries[0].ResourceErr)
+	})
+}
+
+func TestGeneratedEmailTemplateClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read maps not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedEmailTemplateClient(newTestBrazeClient(t, func(*brazeclienttesting.Server) {}))
+
+		_, err := client.Read(t.Context(), "missing-email-template")
+
+		require.Error(t, err)
+		assert.True(t, isBrazeObjectNotFound(err))
+	})
+
+	t.Run("create returns hydrated model", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedEmailTemplateClient(newTestBrazeClient(t, func(*brazeclienttesting.Server) {}))
+
+		actual, err := client.Create(t.Context(), brazeEmailTemplateModel{
+			TemplateName:    types.StringValue("Created email template"),
+			Subject:         types.StringValue("Created subject"),
+			Body:            types.StringValue("<p>Created</p>"),
+			PlaintextBody:   types.StringValue("Created"),
+			Preheader:       types.StringValue("Created preview"),
+			Tags:            NewTypedListFromStringSlice([]string{"tag2"}),
+			ShouldInlineCSS: types.BoolValue(true),
+		})
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, actual.ID.ValueString())
+		assert.Equal(t, "Created email template", actual.TemplateName.ValueString())
+		assert.Equal(t, "Created subject", actual.Subject.ValueString())
+		assert.Equal(t, "<p>Created</p>", actual.Body.ValueString())
+		assert.Equal(t, "Created", actual.PlaintextBody.ValueString())
+		assert.Equal(t, "Created preview", actual.Preheader.ValueString())
+		assert.Equal(t, []string{"tag2"}, TypedListToStringSlice(actual.Tags))
+		assert.True(t, actual.ShouldInlineCSS.ValueBool())
+	})
+
+	t.Run("list hydrates resources", func(t *testing.T) {
+		t.Parallel()
+
+		shouldInlineCSS := true
+		client := newGeneratedEmailTemplateClient(newTestBrazeClient(t, func(server *brazeclienttesting.Server) {
+			server.SetEmailTemplate("existing-email-template", "Existing email template", "Subject", "<p>Body</p>", "Body", "Preview", []string{"tag1"}, &shouldInlineCSS)
+		}))
+
+		entries, err := client.List(t.Context(), brazeObjectListQuery{
+			Limit:           1,
+			IncludeResource: true,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "existing-email-template", entries[0].ID)
+		assert.Equal(t, "Existing email template", entries[0].DisplayName)
+		require.NotNil(t, entries[0].Resource)
+		assert.Equal(t, "Subject", entries[0].Resource.Subject.ValueString())
+		assert.NoError(t, entries[0].ResourceErr)
+	})
+}
+
+func newTestBrazeClient(t *testing.T, configure func(*brazeclienttesting.Server)) *brazeclient.Client {
+	t.Helper()
+
+	server, err := brazeclienttesting.NewBrazeServer()
+	require.NoError(t, err)
+
+	configure(server)
+
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	client, err := brazeclient.NewClient(
+		httpServer.URL,
+		NewBrazeAPIKeySecuritySource("test"),
+		brazeclient.WithClient(httpServer.Client()),
+	)
+	require.NoError(t, err)
+
+	return client
+}
+
+func makeRangeStrings(count int) []string {
+	items := make([]string, count)
+	for i := range items {
+		items[i] = strconv.Itoa(i)
+	}
+
+	return items
+}

--- a/internal/provider/braze_provider.go
+++ b/internal/provider/braze_provider.go
@@ -132,7 +132,8 @@ func (p *brazeProvider) Configure(ctx context.Context, req provider.ConfigureReq
 	}
 
 	providerData := brazeProviderData{
-		client: brazeClient,
+		contentBlocks:  newGeneratedContentBlockClient(brazeClient),
+		emailTemplates: newGeneratedEmailTemplateClient(brazeClient),
 	}
 
 	resp.ActionData = providerData

--- a/internal/provider/braze_provider_data.go
+++ b/internal/provider/braze_provider_data.go
@@ -1,9 +1,6 @@
 package provider
 
-import (
-	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
-)
-
 type brazeProviderData struct {
-	client *brazeclient.Client
+	contentBlocks  contentBlockClient
+	emailTemplates emailTemplateClient
 }

--- a/internal/provider/state.go
+++ b/internal/provider/state.go
@@ -15,15 +15,6 @@ type stateValueSettable interface {
 	Set(ctx context.Context, value any) diag.Diagnostics
 }
 
-func setIdentity(ctx context.Context, identity stateAttributeValueSettable, state stateAttributeValueSettable, contentBlockID string) diag.Diagnostics {
-	diags := diag.Diagnostics{}
-
-	diags.Append(identity.SetAttribute(ctx, path.Root("id"), contentBlockID)...)
-	diags.Append(state.SetAttribute(ctx, path.Root("id"), contentBlockID)...)
-
-	return diags
-}
-
 func setIdentityAndState(ctx context.Context, identity stateAttributeValueSettable, state stateValueSettable, contentBlockID string, value any) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 


### PR DESCRIPTION
## Summary

- add provider-owned adapters for Content Blocks and Email Templates
- move generated Braze client request/response/list handling out of Terraform resource methods
- share the common list query, list entry, pagination, empty-response, and not-found handling
- add focused adapter tests for pagination, not-found mapping, create hydration, and list hydration

## Why

The Terraform resource and list-resource implementations were coupled directly to generated OAS client types. The new adapters keep generated API details in one layer while preserving the existing Terraform behavior.

The shared abstraction is deliberately narrow. Content Blocks and Email Templates have common list/read/hydration structure, but their create/update request shapes still differ enough that a generic CRUD adapter would be shallow.

## Validation

- `go test ./...`
