### PR TITLE
test(provider): improve coverage

### DIFF
--- a/internal/provider/braze_object_adapter_test.go
+++ b/internal/provider/braze_object_adapter_test.go
@@ -2,6 +2,7 @@
 package provider
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -260,6 +261,38 @@ func TestGeneratedEmailTemplateClient(t *testing.T) {
 		assert.True(t, actual.ShouldInlineCSS.ValueBool())
 	})
 
+	t.Run("update returns hydrated model", func(t *testing.T) {
+		t.Parallel()
+
+		shouldInlineCSS := true
+		client := newGeneratedEmailTemplateClient(newTestBrazeClient(t, func(server *brazeclienttesting.Server) {
+			server.SetEmailTemplate("existing-email-template", "Existing email template", "Subject", "<p>Body</p>", "Body", "Preview", []string{"tag1"}, &shouldInlineCSS)
+		}))
+
+		actual, err := client.Update(t.Context(), brazeEmailTemplateModel{
+			IDIdentityModel: IDIdentityModel{
+				ID: types.StringValue("existing-email-template"),
+			},
+			TemplateName:    types.StringValue("Updated email template"),
+			Subject:         types.StringValue("Updated subject"),
+			Body:            types.StringValue("<p>Updated</p>"),
+			PlaintextBody:   types.StringValue("Updated"),
+			Preheader:       types.StringValue("Updated preview"),
+			Tags:            NewTypedListFromStringSlice([]string{"tag2"}),
+			ShouldInlineCSS: types.BoolValue(false),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "existing-email-template", actual.ID.ValueString())
+		assert.Equal(t, "Updated email template", actual.TemplateName.ValueString())
+		assert.Equal(t, "Updated subject", actual.Subject.ValueString())
+		assert.Equal(t, "<p>Updated</p>", actual.Body.ValueString())
+		assert.Equal(t, "Updated", actual.PlaintextBody.ValueString())
+		assert.Equal(t, "Updated preview", actual.Preheader.ValueString())
+		assert.Equal(t, []string{"tag2"}, TypedListToStringSlice(actual.Tags))
+		assert.False(t, actual.ShouldInlineCSS.ValueBool())
+	})
+
 	t.Run("list hydrates resources", func(t *testing.T) {
 		t.Parallel()
 
@@ -283,15 +316,71 @@ func TestGeneratedEmailTemplateClient(t *testing.T) {
 	})
 }
 
+func TestGeneratedCatalogClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read returns hydrated model", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedCatalogClient(newTestBrazeClient(t, withTestCatalog(t)))
+
+		actual, err := client.Read(t.Context(), "centres")
+
+		require.NoError(t, err)
+		assert.Equal(t, "centres", actual.Name.ValueString())
+		assert.Equal(t, "Centre metadata", actual.Description.ValueString())
+		assert.Equal(t, int64(0), actual.NumItems.ValueInt64())
+		assert.False(t, actual.UpdatedAt.IsNull())
+	})
+
+	t.Run("read missing maps not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedCatalogClient(newTestBrazeClient(t, func(*brazeclienttesting.Server) {}))
+
+		_, err := client.Read(t.Context(), "missing-catalog")
+
+		require.Error(t, err)
+		assert.True(t, isBrazeObjectNotFound(err))
+	})
+
+	t.Run("delete removes catalog", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedCatalogClient(newTestBrazeClient(t, withTestCatalog(t)))
+
+		err := client.Delete(t.Context(), "centres")
+		require.NoError(t, err)
+
+		_, err = client.Read(t.Context(), "centres")
+		require.Error(t, err)
+		assert.True(t, isBrazeObjectNotFound(err))
+	})
+
+	t.Run("list returns resource entries", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedCatalogClient(newTestBrazeClient(t, withTestCatalog(t)))
+
+		entries, err := client.List(t.Context())
+
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "centres", entries[0].ID)
+		assert.Equal(t, "centres", entries[0].DisplayName)
+		require.NotNil(t, entries[0].Resource)
+		assert.Equal(t, "Centre metadata", entries[0].Resource.Description.ValueString())
+		assert.NoError(t, entries[0].ResourceErr)
+	})
+}
+
 func TestGeneratedCatalogItemClient(t *testing.T) {
 	t.Parallel()
 
 	t.Run("create uses item-addressed endpoint", func(t *testing.T) {
 		t.Parallel()
 
-		client := newGeneratedCatalogItemClient(newTestBrazeClient(t, func(server *brazeclienttesting.Server) {
-			createTestCatalog(t, server)
-		}))
+		client := newGeneratedCatalogItemClient(newTestBrazeClient(t, withTestCatalog(t)))
 
 		actual, err := client.Create(t.Context(), brazeCatalogItemModel{
 			CatalogName: types.StringValue("centres"),
@@ -302,6 +391,56 @@ func TestGeneratedCatalogItemClient(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "centres/airportwest", actual.ID.ValueString())
 		assert.JSONEq(t, `{"name":"Airport West"}`, actual.ValuesJSON.ValueString())
+	})
+
+	t.Run("read maps not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedCatalogItemClient(newTestBrazeClient(t, withTestCatalog(t)))
+
+		_, err := client.Read(t.Context(), "centres", "missing-centre")
+
+		require.Error(t, err)
+		assert.True(t, isBrazeObjectNotFound(err))
+	})
+
+	t.Run("update replaces item values", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedCatalogItemClient(newTestBrazeClient(t, func(server *brazeclienttesting.Server) {
+			createTestCatalog(t, server)
+			server.SetCatalogItem("centres", "airportwest", map[string]json.RawMessage{
+				"name": json.RawMessage(`"Airport West"`),
+			})
+		}))
+
+		actual, err := client.Update(t.Context(), brazeCatalogItemModel{
+			CatalogName: types.StringValue("centres"),
+			ItemID:      types.StringValue("airportwest"),
+			ValuesJSON:  jsontypes.NewNormalizedValue(`{"active":true,"name":"Airport West"}`),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "centres/airportwest", actual.ID.ValueString())
+		assert.JSONEq(t, `{"active":true,"name":"Airport West"}`, actual.ValuesJSON.ValueString())
+	})
+
+	t.Run("delete removes item", func(t *testing.T) {
+		t.Parallel()
+
+		client := newGeneratedCatalogItemClient(newTestBrazeClient(t, func(server *brazeclienttesting.Server) {
+			createTestCatalog(t, server)
+			server.SetCatalogItem("centres", "airportwest", map[string]json.RawMessage{
+				"name": json.RawMessage(`"Airport West"`),
+			})
+		}))
+
+		err := client.Delete(t.Context(), "centres", "airportwest")
+		require.NoError(t, err)
+
+		_, err = client.Read(t.Context(), "centres", "airportwest")
+		require.Error(t, err)
+		assert.True(t, isBrazeObjectNotFound(err))
 	})
 
 	t.Run("write item rejects id in request body", func(t *testing.T) {
@@ -424,6 +563,14 @@ func createTestCatalog(t *testing.T, server *brazeclienttesting.Server) {
 		}),
 	})
 	require.NoError(t, err)
+}
+
+func withTestCatalog(t *testing.T) func(*brazeclienttesting.Server) {
+	t.Helper()
+
+	return func(server *brazeclienttesting.Server) {
+		createTestCatalog(t, server)
+	}
 }
 
 func makeRangeStrings(count int) []string {

--- a/internal/provider/http_client_rate_limit_test.go
+++ b/internal/provider/http_client_rate_limit_test.go
@@ -8,6 +8,23 @@ import (
 	"time"
 )
 
+func TestBrazeRateLimitBackoffUsesRateLimitDelay(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header: http.Header{
+			"Retry-After": []string{"12"},
+		},
+	}
+
+	delay := brazeRateLimitBackoff(time.Second, time.Minute, 1, resp)
+
+	if delay != 12*time.Second {
+		t.Fatalf("expected 12s delay, got %s", delay)
+	}
+}
+
 func TestRateLimitDelayUsesRetryAfterSeconds(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/http_client_user_agent_test.go
+++ b/internal/provider/http_client_user_agent_test.go
@@ -1,0 +1,92 @@
+package provider_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/cysp/terraform-provider-braze/internal/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errTestTransport = errors.New("transport failed")
+
+func TestHTTPClientWithUserAgentDo(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		userAgent         string
+		requestUserAgent  string
+		expectedUserAgent string
+	}{
+		"sets configured user agent": {
+			userAgent:         "terraform-provider-braze/test",
+			expectedUserAgent: "terraform-provider-braze/test",
+		},
+		"preserves existing user agent": {
+			userAgent:         "terraform-provider-braze/test",
+			requestUserAgent:  "custom-client",
+			expectedUserAgent: "custom-client",
+		},
+		"leaves user agent empty when unconfigured": {},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client := provider.NewHTTPClientWithUserAgent(&http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					assert.Equal(t, test.expectedUserAgent, req.Header.Get("User-Agent"))
+
+					return &http.Response{
+						StatusCode: http.StatusNoContent,
+						Header:     make(http.Header),
+						Body:       http.NoBody,
+						Request:    req,
+					}, nil
+				}),
+			}, test.userAgent)
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.test", nil)
+			require.NoError(t, err)
+
+			if test.requestUserAgent != "" {
+				req.Header.Set("User-Agent", test.requestUserAgent)
+			}
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}
+
+func TestHTTPClientWithUserAgentDoWrapsTransportError(t *testing.T) {
+	t.Parallel()
+
+	client := provider.NewHTTPClientWithUserAgent(&http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errTestTransport
+		}),
+	}, "terraform-provider-braze/test")
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.test", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+	}
+
+	require.ErrorIs(t, err, errTestTransport)
+	assert.Contains(t, err.Error(), "http client do")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}


### PR DESCRIPTION
## Summary

- Add generated-client adapter coverage for catalog read/list/delete, catalog item read/update/delete, and email template update behavior.
- Add direct tests for Braze rate-limit backoff and HTTP user-agent transport behavior.
- Reuse the existing fake Braze server helpers and a tiny RoundTripper stub to keep the tests focused and low-overhead.

## Impact

This raises provider package coverage around the provider-owned client adapters and transport helpers without expanding Terraform acceptance-test configuration surface area.

## Validation

```sh
GOCACHE=/private/tmp/terraform-provider-braze-gocache go test ./... -coverprofile=coverage.out -covermode=atomic
```

Provider package coverage: 57.4%.