### PR TITLE
refactor(client): generate catalog values as json.RawMessage

### DIFF
--- a/internal/braze-client-go/oas_json_gen.go
+++ b/internal/braze-client-go/oas_json_gen.go
@@ -3,6 +3,7 @@
 package brazeclient
 
 import (
+	json2 "encoding/json"
 	"math/bits"
 	"strconv"
 	"time"
@@ -364,9 +365,7 @@ func (s *CatalogItem) encodeFields(e *jx.Encoder) {
 	for k, elem := range s.AdditionalProps {
 		e.FieldStart(k)
 
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
+		json.EncodeJSON(e, elem)
 	}
 }
 
@@ -380,7 +379,7 @@ func (s *CatalogItem) Decode(d *jx.Decoder) error {
 		return errors.New("invalid: unable to decode CatalogItem to nil")
 	}
 	var requiredBitSet [1]uint8
-	s.AdditionalProps = map[string]jx.Raw{}
+	s.AdditionalProps = map[string]json2.RawMessage{}
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -397,10 +396,10 @@ func (s *CatalogItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"id\"")
 			}
 		default:
-			var elem jx.Raw
+			var elem json2.RawMessage
 			if err := func() error {
-				v, err := d.RawAppend(nil)
-				elem = jx.Raw(v)
+				v, err := json.DecodeJSON[json2.RawMessage](d)
+				elem = v
 				if err != nil {
 					return err
 				}
@@ -475,9 +474,7 @@ func (s CatalogItemAdditional) encodeFields(e *jx.Encoder) {
 	for k, elem := range s {
 		e.FieldStart(k)
 
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
+		json.EncodeJSON(e, elem)
 	}
 }
 
@@ -488,10 +485,10 @@ func (s *CatalogItemAdditional) Decode(d *jx.Decoder) error {
 	}
 	m := s.init()
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
+		var elem json2.RawMessage
 		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
+			v, err := json.DecodeJSON[json2.RawMessage](d)
+			elem = v
 			if err != nil {
 				return err
 			}
@@ -629,9 +626,7 @@ func (s CatalogItemWrite) encodeFields(e *jx.Encoder) {
 	for k, elem := range s {
 		e.FieldStart(k)
 
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
+		json.EncodeJSON(e, elem)
 	}
 }
 
@@ -642,10 +637,10 @@ func (s *CatalogItemWrite) Decode(d *jx.Decoder) error {
 	}
 	m := s.init()
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
+		var elem json2.RawMessage
 		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
+			v, err := json.DecodeJSON[json2.RawMessage](d)
+			elem = v
 			if err != nil {
 				return err
 			}

--- a/internal/braze-client-go/oas_schemas_gen.go
+++ b/internal/braze-client-go/oas_schemas_gen.go
@@ -3,11 +3,11 @@
 package brazeclient
 
 import (
+	json2 "encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/go-faster/errors"
-	"github.com/go-faster/jx"
 )
 
 func (s *ErrorResponseStatusCode) Error() string {
@@ -226,12 +226,12 @@ func (s *CatalogItem) SetAdditionalProps(val CatalogItemAdditional) {
 	s.AdditionalProps = val
 }
 
-type CatalogItemAdditional map[string]jx.Raw
+type CatalogItemAdditional map[string]json2.RawMessage
 
 func (s *CatalogItemAdditional) init() CatalogItemAdditional {
 	m := *s
 	if m == nil {
-		m = map[string]jx.Raw{}
+		m = map[string]json2.RawMessage{}
 		*s = m
 	}
 	return m
@@ -253,12 +253,12 @@ func (s *CatalogItemOperationResponse) SetMessage(val string) {
 }
 
 // Ref: #/CatalogItemWrite
-type CatalogItemWrite map[string]jx.Raw
+type CatalogItemWrite map[string]json2.RawMessage
 
 func (s *CatalogItemWrite) init() CatalogItemWrite {
 	m := *s
 	if m == nil {
-		m = map[string]jx.Raw{}
+		m = map[string]json2.RawMessage{}
 		*s = m
 	}
 	return m

--- a/internal/braze-client-go/openapi/schemas/catalog_items/item.yml
+++ b/internal/braze-client-go/openapi/schemas/catalog_items/item.yml
@@ -2,7 +2,8 @@ CatalogItem:
   type: object
   required:
     - id
-  additionalProperties: true
+  additionalProperties:
+    x-ogen-type: encoding/json.RawMessage
   properties:
     id:
       type: string

--- a/internal/braze-client-go/openapi/schemas/catalog_items/write_item.yml
+++ b/internal/braze-client-go/openapi/schemas/catalog_items/write_item.yml
@@ -1,6 +1,7 @@
 CatalogItemWrite:
   type: object
-  additionalProperties: true
+  additionalProperties:
+    x-ogen-type: encoding/json.RawMessage
   not:
     required:
       - id

--- a/internal/braze-client-go/testing/handler_catalogs.go
+++ b/internal/braze-client-go/testing/handler_catalogs.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"time"
 
 	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
-	"github.com/go-faster/jx"
 )
 
 const catalogItemsPageSize = 50
@@ -70,14 +70,9 @@ func (s *Server) SetCatalogItem(catalogName string, itemID string, fields map[st
 		s.handler.catalogItems[catalogName] = map[string]brazeclient.CatalogItem{}
 	}
 
-	additional := make(brazeclient.CatalogItemAdditional, len(fields))
-	for name, value := range fields {
-		additional[name] = jx.Raw(value)
-	}
-
 	s.handler.catalogItems[catalogName][itemID] = brazeclient.CatalogItem{
 		ID:              itemID,
-		AdditionalProps: additional,
+		AdditionalProps: maps.Clone(brazeclient.CatalogItemAdditional(fields)),
 	}
 }
 

--- a/internal/provider/braze_catalog_item_model.go
+++ b/internal/provider/braze_catalog_item_model.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	brazeclient "github.com/cysp/terraform-provider-braze/internal/braze-client-go"
-	"github.com/go-faster/jx"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -39,22 +38,11 @@ func (m brazeCatalogItemModel) ToCatalogItemWrite() (brazeclient.CatalogItemWrit
 		return nil, errCatalogItemValuesJSONIncludesID
 	}
 
-	item := make(brazeclient.CatalogItemWrite, len(values))
-	for key, value := range values {
-		item[key] = jx.Raw(value)
-	}
-
-	return item, nil
+	return brazeclient.CatalogItemWrite(values), nil
 }
 
 func newBrazeCatalogItemModelFromCatalogItem(catalogName string, item brazeclient.CatalogItem) (brazeCatalogItemModel, error) {
-	values := map[string]json.RawMessage{}
-
-	for key, value := range item.GetAdditionalProps() {
-		values[key] = json.RawMessage(value)
-	}
-
-	raw, err := json.Marshal(values)
+	raw, err := json.Marshal(map[string]json.RawMessage(item.GetAdditionalProps()))
 	if err != nil {
 		return brazeCatalogItemModel{}, fmt.Errorf("marshal values_json: %w", err)
 	}


### PR DESCRIPTION
## What

- configure the catalog item OpenAPI schemas to generate additional properties as `encoding/json.RawMessage`
- regenerate the ogen client
- remove provider and test-server conversions between `json.RawMessage` and `jx.Raw`

## Why

ogen 1.23 supports `x-ogen-type` for `additionalProperties`. Catalog values are already represented as `json.RawMessage` at the provider boundary, so generating that type directly removes an internal representation mismatch and its conversion loops.

## Impact

There is no Terraform schema or Braze API behavior change. Catalog values remain arbitrary JSON. The generated client now exposes the standard-library raw JSON type used by its callers.

## Checks

- `TF_ACC=1 go test ./internal/provider -run '^TestAccBrazeCatalogItemImport$' -count=1 -v`
- `go generate ./...`
- `git diff --check`
- `go test ./...`
