### PR TITLE
refactor(testing): use ogen IsEmpty for nullable updates

### DIFF
--- a/internal/braze-client-go/testing/handler_content_blocks.go
+++ b/internal/braze-client-go/testing/handler_content_blocks.go
@@ -108,7 +108,7 @@ func (h *Handler) UpdateContentBlock(_ context.Context, req *brazeclient.UpdateC
 		block.Content = req.Content.Value
 	}
 
-	if req.Description.IsSet() {
+	if !req.Description.IsEmpty() {
 		if req.Description.IsNull() {
 			block.Description.SetToNull()
 		} else {
@@ -116,7 +116,7 @@ func (h *Handler) UpdateContentBlock(_ context.Context, req *brazeclient.UpdateC
 		}
 	}
 
-	if req.Tags.IsSet() {
+	if !req.Tags.IsEmpty() {
 		if req.Tags.IsNull() {
 			block.Tags.SetToNull()
 		} else {

--- a/internal/braze-client-go/testing/handler_email_templates.go
+++ b/internal/braze-client-go/testing/handler_email_templates.go
@@ -103,27 +103,27 @@ func (h *Handler) UpdateEmailTemplate(_ context.Context, req *brazeclient.Update
 		template.TemplateName = templateName
 	}
 
-	if req.Subject.IsSet() {
+	if !req.Subject.IsEmpty() {
 		template.Subject = req.Subject
 	}
 
-	if req.Body.IsSet() {
+	if !req.Body.IsEmpty() {
 		template.Body = req.Body
 	}
 
-	if req.PlaintextBody.IsSet() {
+	if !req.PlaintextBody.IsEmpty() {
 		template.PlaintextBody = req.PlaintextBody
 	}
 
-	if req.Preheader.IsSet() {
+	if !req.Preheader.IsEmpty() {
 		template.Preheader = req.Preheader
 	}
 
-	if req.ShouldInlineCSS.IsSet() {
+	if !req.ShouldInlineCSS.IsEmpty() {
 		template.ShouldInlineCSS = req.ShouldInlineCSS
 	}
 
-	if req.Tags.IsSet() {
+	if !req.Tags.IsEmpty() {
 		if req.Tags.IsNull() {
 			template.Tags.SetToNull()
 		} else {


### PR DESCRIPTION
## What

Use ogen's generated `IsEmpty()` helper for nullable fields in the content block and email template update handlers.

## Why

These handlers need to distinguish an omitted field from a supplied field, including an explicit JSON `null`. `!IsEmpty()` states that intent directly now that ogen generates the helper for nullable option types.

## Impact

This is a behavior-preserving test-server refactor:

- omitted fields remain unchanged
- non-null values are applied
- explicit `null` values are still applied as null

## Checks

- `git diff --check`
- `go test ./...`
